### PR TITLE
feat: add 6 Docker inspect tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MCP server for the [Komodo](https://komo.do) DevOps platform. Manage servers, st
 
 ## Features
 
-- **40 tools** across **12 resource categories** covering the complete Komodo DevOps API
+- **46 tools** across **12 resource categories** covering the complete Komodo DevOps API
 - **Three access tiers** (`read-only`, `read-execute`, `full`) for granular control
 - **Category filtering** via `KOMODO_CATEGORIES` to expose only the tools you need
 - **Zero HTTP dependencies** -- uses the official `komodo_client` SDK
@@ -65,15 +65,15 @@ Control which tools are available using the `KOMODO_ACCESS_TIER` environment var
 
 | Tier | Tools | Description |
 |------|-------|-------------|
-| `full` (default) | 40 | Read, execute, and write -- full control |
-| `read-execute` | 39 | Read and execute -- no resource creation/deletion via write tool |
-| `read-only` | 25 | Read only -- safe for exploration, no state changes |
+| `full` (default) | 46 | Read, execute, and write -- full control |
+| `read-execute` | 45 | Read and execute -- no resource creation/deletion via write tool |
+| `read-only` | 31 | Read only -- safe for exploration, no state changes |
 
 **Tier details:**
 
-- **full**: All 40 tools. Includes `komodo_write_resource` for creating, updating, and deleting Komodo resources.
-- **read-execute**: 39 tools. All read tools plus execute tools (deploy, lifecycle, run, etc.). The `komodo_write_resource` tool is hidden.
-- **read-only**: 25 tools. List, get, logs, and stats only. All execute and write tools are hidden.
+- **full**: All 46 tools. Includes `komodo_write_resource` for creating, updating, and deleting Komodo resources.
+- **read-execute**: 45 tools. All read tools plus execute tools (deploy, lifecycle, run, etc.). The `komodo_write_resource` tool is hidden.
+- **read-only**: 31 tools. List, get, logs, inspect, and stats only. All execute and write tools are hidden.
 
 Tools that are not available in your tier are not registered with the MCP server. They will not appear in your AI tool's tool list, keeping the context clean.
 
@@ -98,10 +98,10 @@ Generate API keys in the Komodo UI under **Settings > API Keys**.
 
 ## Tools
 
-mcp-komodo provides 40 tools organized by category. Each tool's Access column shows the minimum tier required: `read-only` (available in all tiers), `read-execute` (requires `read-execute` or `full`), or `full` (requires `full` tier only).
+mcp-komodo provides 46 tools organized by category. Each tool's Access column shows the minimum tier required: `read-only` (available in all tiers), `read-execute` (requires `read-execute` or `full`), or `full` (requires `full` tier only).
 
 <details>
-<summary>Servers (6 tools)</summary>
+<summary>Servers (10 tools)</summary>
 
 | Tool | Description | Access |
 |------|-------------|--------|
@@ -109,19 +109,24 @@ mcp-komodo provides 40 tools organized by category. Each tool's Access column sh
 | `komodo_get_server` | Get server configuration, status, and action state | read-only |
 | `komodo_get_server_stats` | Get CPU, memory, disk usage, and load averages | read-only |
 | `komodo_get_server_info` | Get OS details, hardware info, and running processes | read-only |
+| `komodo_inspect_docker_container` | Inspect a Docker container (equivalent to docker inspect) | read-only |
+| `komodo_inspect_docker_image` | Inspect a Docker image (equivalent to docker image inspect) | read-only |
+| `komodo_inspect_docker_network` | Inspect a Docker network (equivalent to docker network inspect) | read-only |
+| `komodo_inspect_docker_volume` | Inspect a Docker volume (equivalent to docker volume inspect) | read-only |
 | `komodo_prune_docker` | Prune unused Docker resources on a server | read-execute |
 | `komodo_delete_docker_resource` | Delete a specific Docker image, volume, or network | read-execute |
 
 </details>
 
 <details>
-<summary>Stacks (6 tools)</summary>
+<summary>Stacks (7 tools)</summary>
 
 | Tool | Description | Access |
 |------|-------------|--------|
 | `komodo_list_stacks` | List all stacks with state, server, and service count | read-only |
 | `komodo_get_stack` | Get stack configuration, services, and action state | read-only |
 | `komodo_get_stack_log` | Get logs from stack services, with optional search | read-only |
+| `komodo_inspect_stack_container` | Inspect a container for a specific service in a stack | read-only |
 | `komodo_deploy_stack` | Deploy or redeploy a stack | read-execute |
 | `komodo_stack_lifecycle` | Start, stop, restart, pause, or unpause a stack | read-execute |
 | `komodo_destroy_stack` | Permanently destroy a stack | read-execute |
@@ -129,13 +134,14 @@ mcp-komodo provides 40 tools organized by category. Each tool's Access column sh
 </details>
 
 <details>
-<summary>Deployments (6 tools)</summary>
+<summary>Deployments (7 tools)</summary>
 
 | Tool | Description | Access |
 |------|-------------|--------|
 | `komodo_list_deployments` | List all deployments with state, image, and server | read-only |
 | `komodo_get_deployment` | Get deployment configuration, container status, and action state | read-only |
 | `komodo_get_deployment_log` | Get container logs, with optional search | read-only |
+| `komodo_inspect_deployment_container` | Inspect the container for a deployment (equivalent to docker inspect) | read-only |
 | `komodo_deploy_deployment` | Deploy with latest image and configuration | read-execute |
 | `komodo_deployment_lifecycle` | Start, stop, restart, pause, or unpause a deployment | read-execute |
 | `komodo_destroy_deployment` | Permanently destroy a deployment | read-execute |
@@ -267,7 +273,7 @@ Check that `KOMODO_URL` is correct and that Komodo Core is reachable from where 
 Verify your API key and secret are correct. Check that the key has not been revoked or expired in the Komodo UI under Settings > API Keys.
 
 **Tools not showing up in your AI tool**
-Check your access tier setting. In `read-only` mode, only 25 tools are registered. In `read-execute` mode, 39 tools are registered. Use `full` (or omit `KOMODO_ACCESS_TIER`) for all 40 tools. Check `KOMODO_CATEGORIES` -- only tools in listed categories are registered. Also verify the server started without errors by checking stderr output.
+Check your access tier setting. In `read-only` mode, only 31 tools are registered. In `read-execute` mode, 45 tools are registered. Use `full` (or omit `KOMODO_ACCESS_TIER`) for all 46 tools. Check `KOMODO_CATEGORIES` -- only tools in listed categories are registered. Also verify the server started without errors by checking stderr output.
 
 **Node.js version errors**
 mcp-komodo requires Node.js >= 18.0.0. Check your version with `node --version`.

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -59,7 +59,12 @@ export function handleKomodoError(
   context: string,
   error: unknown,
 ): McpErrorResponse {
-  const rawMessage = error instanceof Error ? error.message : String(error);
+  const rawMessage =
+    error instanceof Error
+      ? error.message
+      : typeof error === "object" && error !== null
+        ? JSON.stringify(error)
+        : String(error);
   const safeMessage = sanitizeMessage(rawMessage);
   return {
     content: [{ type: "text", text: `Error ${context}: ${safeMessage}` }],

--- a/src/tools/servers.ts
+++ b/src/tools/servers.ts
@@ -1,7 +1,7 @@
 /**
- * Server domain tools: list, get, stats, info+processes, Docker prune, Docker delete.
+ * Server domain tools: list, get, stats, info+processes, Docker inspect, Docker prune, Docker delete.
  *
- * Registers 6 MCP tools for Komodo Server resources.
+ * Registers 10 MCP tools for Komodo Server resources.
  * A Server is a remote machine managed by Komodo's Periphery agent.
  */
 
@@ -176,6 +176,142 @@ export function registerServerTools(server: McpServer, client: KomodoClient, con
           `getting info for server '${serverParam}'`,
           error,
         );
+      }
+    },
+  });
+
+  // -------------------------------------------------------------------------
+  // komodo_inspect_docker_container
+  // -------------------------------------------------------------------------
+  registerTool(server, config, {
+    name: "komodo_inspect_docker_container",
+    description:
+      "Inspect a Docker container on a Komodo Server. Returns the full " +
+      "container state including configuration, mounts, network settings, " +
+      "and runtime status (equivalent to docker inspect).",
+    accessTier: "read-only",
+    category: "servers",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+    },
+    inputSchema: {
+      server: z.string().describe("Server name or ID"),
+      container: z.string().describe("Container name or ID"),
+    },
+    handler: async (args) => {
+      const serverParam = args.server as string;
+      const container = args.container as string;
+      try {
+        const result = await client.read("InspectDockerContainer", { server: serverParam, container });
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (error) {
+        return handleKomodoError(`inspecting container '${container}' on server '${serverParam}'`, error);
+      }
+    },
+  });
+
+  // -------------------------------------------------------------------------
+  // komodo_inspect_docker_image
+  // -------------------------------------------------------------------------
+  registerTool(server, config, {
+    name: "komodo_inspect_docker_image",
+    description:
+      "Inspect a Docker image on a Komodo Server. Returns the full image " +
+      "metadata including layers, configuration, labels, and creation info " +
+      "(equivalent to docker image inspect).",
+    accessTier: "read-only",
+    category: "servers",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+    },
+    inputSchema: {
+      server: z.string().describe("Server name or ID"),
+      image: z.string().describe("Image name or ID (e.g., nginx:latest)"),
+    },
+    handler: async (args) => {
+      const serverParam = args.server as string;
+      const image = args.image as string;
+      try {
+        const result = await client.read("InspectDockerImage", { server: serverParam, image });
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (error) {
+        return handleKomodoError(`inspecting image '${image}' on server '${serverParam}'`, error);
+      }
+    },
+  });
+
+  // -------------------------------------------------------------------------
+  // komodo_inspect_docker_network
+  // -------------------------------------------------------------------------
+  registerTool(server, config, {
+    name: "komodo_inspect_docker_network",
+    description:
+      "Inspect a Docker network on a Komodo Server. Returns the full " +
+      "network configuration including driver, IPAM settings, connected " +
+      "containers, and options (equivalent to docker network inspect).",
+    accessTier: "read-only",
+    category: "servers",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+    },
+    inputSchema: {
+      server: z.string().describe("Server name or ID"),
+      network: z.string().describe("Network name or ID"),
+    },
+    handler: async (args) => {
+      const serverParam = args.server as string;
+      const network = args.network as string;
+      try {
+        const result = await client.read("InspectDockerNetwork", { server: serverParam, network });
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (error) {
+        return handleKomodoError(`inspecting network '${network}' on server '${serverParam}'`, error);
+      }
+    },
+  });
+
+  // -------------------------------------------------------------------------
+  // komodo_inspect_docker_volume
+  // -------------------------------------------------------------------------
+  registerTool(server, config, {
+    name: "komodo_inspect_docker_volume",
+    description:
+      "Inspect a Docker volume on a Komodo Server. Returns the full " +
+      "volume metadata including driver, mount point, labels, and options " +
+      "(equivalent to docker volume inspect).",
+    accessTier: "read-only",
+    category: "servers",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+    },
+    inputSchema: {
+      server: z.string().describe("Server name or ID"),
+      volume: z.string().describe("Volume name"),
+    },
+    handler: async (args) => {
+      const serverParam = args.server as string;
+      const volume = args.volume as string;
+      try {
+        const result = await client.read("InspectDockerVolume", { server: serverParam, volume });
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (error) {
+        return handleKomodoError(`inspecting volume '${volume}' on server '${serverParam}'`, error);
       }
     },
   });


### PR DESCRIPTION
## Summary

- Add 6 new read-only Docker inspect tools (`InspectDockerContainer`, `InspectDockerImage`, `InspectDockerNetwork`, `InspectDockerVolume`, `InspectStackContainer`, `InspectDeploymentContainer`) using the `komodo_client` SDK
- Fix `handleKomodoError` to properly serialize non-Error objects (was producing `[object Object]`, now shows full error details via `JSON.stringify`)
- Update README tool counts (40 → 46) and tool tables

## Test plan

- [x] `npm run build` passes with no TypeScript errors
- [x] All 6 tools tested via MCP Inspector against live Komodo instance
- [x] Verified JSON output is properly formatted for containers, images, networks, and volumes
- [x] Verified error responses return sanitized, informative messages (no credential leaks)
- [x] Confirmed all new tools are `read-only` tier and appear in all access tiers