### PR TITLE
feat: read server version from package.json

### DIFF
--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -8,6 +8,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { logger } from "./logger.js";
+import pkg from "../../package.json" with { type: "json" };
 
 /**
  * Create a new MCP server instance.
@@ -16,7 +17,7 @@ export function createServer(): McpServer {
   return new McpServer(
     {
       name: "mcp-komodo",
-      version: "0.1.0",
+      version: pkg.version,
     },
     {
       capabilities: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "Node16",
-    "moduleResolution": "Node16",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
## Summary
- Replace hardcoded version string with static JSON import from package.json
- Upgrade tsconfig module from Node16 to NodeNext to support import attributes

## Test plan
- [x] npm run build passes