### PR TITLE
feat: add Docker support and HTTP transport

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+.git
+.github
+*.md
+.env
+.env.*

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,3 +40,45 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm publish --access public
+
+  docker:
+    name: Build & Push Docker Image
+    if: github.event_name == 'release'
+    needs: ci
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/samik081/mcp-komodo
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY tsconfig.json ./
+COPY src/ ./src/
+RUN npm run build
+
+FROM node:22-alpine
+ENV NODE_ENV=production
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev && \
+    addgroup -g 1001 -S mcp && adduser -u 1001 -S mcp -G mcp
+COPY --from=builder /app/dist ./dist
+USER mcp
+ENV MCP_PORT=3000
+ENV MCP_HOST=0.0.0.0
+EXPOSE 3000
+ENTRYPOINT ["node", "dist/index.js"]

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -12,6 +12,9 @@ export interface AppConfig {
   accessTier: AccessTier;
   categories: string[] | null;
   debug: boolean;
+  transport: 'stdio' | 'http';
+  httpPort: number;
+  httpHost: string;
 }
 
 /**
@@ -63,6 +66,17 @@ export function loadConfig(): AppConfig {
     );
   }
 
+  const transport =
+    process.env.MCP_TRANSPORT === 'http' ? ('http' as const) : ('stdio' as const);
+  const rawPort = process.env.MCP_PORT ?? '3000';
+  const httpPort = parseInt(rawPort, 10);
+  if (isNaN(httpPort) || httpPort < 1 || httpPort > 65535) {
+    throw new Error(
+      `Invalid MCP_PORT: "${rawPort}". Must be an integer between 1 and 65535.`,
+    );
+  }
+  const httpHost = process.env.MCP_HOST ?? '0.0.0.0';
+
   return {
     url: url!.replace(/\/+$/, ''),
     apiKey: apiKey!,
@@ -70,5 +84,8 @@ export function loadConfig(): AppConfig {
     accessTier: parseAccessTier(),
     categories: parseCategories(process.env.KOMODO_CATEGORIES),
     debug: Boolean(process.env.DEBUG),
+    transport,
+    httpPort,
+    httpHost,
   };
 }

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -1,37 +1,139 @@
 /**
  * MCP server factory.
  *
- * Creates the McpServer instance with project identity
- * and provides a startServer() to connect stdio transport.
+ * Creates the McpServer instance and provides startServer()
+ * which selects stdio or HTTP transport based on config.
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import {
+  createServer as createHttpServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import { randomUUID } from "node:crypto";
+import type { AppConfig } from "./config.js";
 import { logger } from "./logger.js";
 import pkg from "../../package.json" with { type: "json" };
 
-/**
- * Create a new MCP server instance.
- */
+const SERVER_NAME = "mcp-komodo";
+
 export function createServer(): McpServer {
   return new McpServer(
-    {
-      name: "mcp-komodo",
-      version: pkg.version,
-    },
-    {
-      capabilities: {
-        tools: {},
-      },
-    },
+    { name: SERVER_NAME, version: pkg.version },
+    { capabilities: { tools: {} } },
   );
 }
 
-/**
- * Start the MCP server on stdio transport.
- */
-export async function startServer(server: McpServer): Promise<void> {
-  const transport = new StdioServerTransport();
-  logger.info("mcp-komodo listening on stdio");
+export async function startServer(
+  server: McpServer,
+  config: AppConfig,
+): Promise<void> {
+  if (config.transport === "http") {
+    await startHttpServer(server, config);
+  } else {
+    const transport = new StdioServerTransport();
+    logger.info(`${SERVER_NAME} v${pkg.version} listening on stdio`);
+    await server.connect(transport);
+  }
+}
+
+const MAX_BODY_BYTES = 4 * 1024 * 1024; // 4 MB
+
+async function parseJsonBody(req: IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    req.on("data", (chunk: Buffer) => {
+      data += chunk.toString();
+      if (data.length > MAX_BODY_BYTES) {
+        req.destroy();
+        reject(new Error("Request body too large"));
+      }
+    });
+    req.on("end", () => {
+      try {
+        resolve(JSON.parse(data));
+      } catch (err) {
+        reject(err);
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+async function startHttpServer(
+  server: McpServer,
+  config: AppConfig,
+): Promise<void> {
+  const { httpHost, httpPort } = config;
+
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: () => randomUUID(),
+  });
+
   await server.connect(transport);
+
+  const httpServer = createHttpServer(
+    async (req: IncomingMessage, res: ServerResponse) => {
+      const url = req.url ?? "";
+
+      if (url === "/health" && req.method === "GET") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            status: "ok",
+            server: SERVER_NAME,
+            version: pkg.version,
+          }),
+        );
+        return;
+      }
+
+      if (url === "/mcp") {
+        try {
+          if (req.method === "POST") {
+            const body = await parseJsonBody(req);
+            await transport.handleRequest(req, res, body);
+          } else {
+            await transport.handleRequest(req, res);
+          }
+        } catch (err) {
+          logger.error("MCP request handling error:", err);
+          if (!res.headersSent) {
+            const status = err instanceof SyntaxError ? 400 : 500;
+            const message =
+              err instanceof SyntaxError ? "Invalid JSON" : "Internal server error";
+            res.writeHead(status, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: message }));
+          }
+        }
+        return;
+      }
+
+      res.writeHead(404);
+      res.end("Not found");
+    },
+  );
+
+  await new Promise<void>((resolve, reject) => {
+    httpServer.listen(httpPort, httpHost, () => {
+      logger.info(
+        `${SERVER_NAME} v${pkg.version} listening on http://${httpHost}:${httpPort}/mcp`,
+      );
+      resolve();
+    });
+    httpServer.once("error", reject);
+  });
+
+  const shutdown = async (signal: string): Promise<void> => {
+    logger.info(`Received ${signal}, shutting down...`);
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+    await transport.close();
+    process.exit(0);
+  };
+
+  process.once("SIGTERM", () => void shutdown("SIGTERM"));
+  process.once("SIGINT", () => void shutdown("SIGINT"));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ async function main(): Promise<void> {
 
   const server = createServer();
   registerAllTools(server, client, config);
-  await startServer(server);
+  await startServer(server, config);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary

- Add multi-arch Docker images (`linux/amd64` + `linux/arm64`) published to GHCR on release, with multi-stage `Dockerfile` and `.dockerignore`
- Add Streamable HTTP transport as an alternative to stdio, controlled by `MCP_TRANSPORT=http` env var, with `/mcp` endpoint, `/health` health check, 4MB body limit, and graceful shutdown
- Add `docker` job to CI/CD workflow (`publish.yml`) that builds and pushes Docker images using Docker Buildx with GitHub Actions cache
- Extend `AppConfig` and `loadConfig()` with `transport`, `httpPort`, `httpHost` fields and `MCP_PORT` validation
- Refactor `server.ts` to select stdio or HTTP transport based on config, using `node:http` and `StreamableHTTPServerTransport`
- Update `startServer()` signature to accept `config` parameter across `server.ts` and `index.ts`
- Update README with Docker badge, Docker quick start, Docker stdio JSON config, Remote MCP JSON config, and `MCP_TRANSPORT`/`MCP_PORT`/`MCP_HOST` env var docs
- Reformatted environment variables table with Default column for consistency