### PR TITLE
fix: serve MCP at root path and return JSON 404 responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ docker run -d -p 3000:3000 \
   ghcr.io/samik081/mcp-komodo
 ```
 
-The MCP endpoint is available at `http://localhost:3000/mcp` and a health check at `http://localhost:3000/health`.
+The MCP endpoint is available at `http://localhost:3000` and a health check at `http://localhost:3000/health`.
 
 ## Configuration
 
@@ -75,6 +75,9 @@ claude mcp add --transport stdio komodo \
   --env KOMODO_API_KEY=your-api-key \
   --env KOMODO_API_SECRET=your-api-secret \
   -- docker run --rm -i ghcr.io/samik081/mcp-komodo
+
+# Using remote HTTP (connect to a running Docker container or HTTP server)
+claude mcp add --transport http komodo http://localhost:3000
 ```
 
 **JSON config** (works with Claude Code `.mcp.json`, Claude Desktop `claude_desktop_config.json`, Cursor `.cursor/mcp.json`):
@@ -120,7 +123,7 @@ claude mcp add --transport stdio komodo \
   "mcpServers": {
     "komodo": {
       "type": "streamable-http",
-      "url": "http://localhost:3000/mcp"
+      "url": "http://localhost:3000"
     }
   }
 }

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -91,7 +91,7 @@ async function startHttpServer(
         return;
       }
 
-      if (url === "/mcp") {
+      if (url === "/") {
         try {
           if (req.method === "POST") {
             const body = await parseJsonBody(req);
@@ -112,15 +112,15 @@ async function startHttpServer(
         return;
       }
 
-      res.writeHead(404);
-      res.end("Not found");
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Not found" }));
     },
   );
 
   await new Promise<void>((resolve, reject) => {
     httpServer.listen(httpPort, httpHost, () => {
       logger.info(
-        `${SERVER_NAME} v${pkg.version} listening on http://${httpHost}:${httpPort}/mcp`,
+        `${SERVER_NAME} v${pkg.version} listening on http://${httpHost}:${httpPort}`,
       );
       resolve();
     });


### PR DESCRIPTION
## Summary
- Move HTTP transport MCP endpoint from `/mcp` to `/` so clients connect at the root path — avoids OAuth discovery failures where Claude Code hits `/.well-known/oauth-authorization-server`, gets a plain-text 404, and fails to parse it as JSON
- Return JSON `{"error":"Not found"}` with `Content-Type: application/json` for 404 responses instead of plain text, preventing `SyntaxError: JSON Parse error` in MCP clients
- Update log message to reflect new root path (no `/mcp` suffix)
- Update README: endpoint URL changed from `/mcp` to root, add `claude mcp add --transport http` CLI example for remote HTTP connections, update Remote MCP JSON config URL

## Files changed
- `src/core/server.ts` — route `/mcp` → `/`, JSON 404 body, updated log message
- `README.md` — endpoint URL, CLI remote HTTP example, Remote MCP JSON config

## Test plan
- [x] Docker build succeeds
- [x] stdio transport: initialize + tool call works
- [x] HTTP transport: session handshake + tool call works