### PR TITLE
feat: add 7 new tools for updates, stack services, summaries, and image pulls

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ MCP server for the [Komodo](https://komo.do) DevOps platform. Manage servers, st
 
 ## Features
 
-- **46 tools** across **12 resource categories** covering the complete Komodo DevOps API
+- **53 tools** across **13 resource categories** covering the complete Komodo DevOps API
 - **Three access tiers** (`read-only`, `read-execute`, `full`) for granular control
 - **Category filtering** via `KOMODO_CATEGORIES` to expose only the tools you need
 - **Zero HTTP dependencies** -- uses the official `komodo_client` SDK
@@ -135,15 +135,15 @@ Control which tools are available using the `KOMODO_ACCESS_TIER` environment var
 
 | Tier | Tools | Description |
 |------|-------|-------------|
-| `full` (default) | 46 | Read, execute, and write -- full control |
-| `read-execute` | 45 | Read and execute -- no resource creation/deletion via write tool |
-| `read-only` | 31 | Read only -- safe for exploration, no state changes |
+| `full` (default) | 53 | Read, execute, and write -- full control |
+| `read-execute` | 52 | Read and execute -- no resource creation/deletion via write tool |
+| `read-only` | 36 | Read only -- safe for exploration, no state changes |
 
 **Tier details:**
 
-- **full**: All 46 tools. Includes `komodo_write_resource` for creating, updating, and deleting Komodo resources.
-- **read-execute**: 45 tools. All read tools plus execute tools (deploy, lifecycle, run, etc.). The `komodo_write_resource` tool is hidden.
-- **read-only**: 31 tools. List, get, logs, inspect, and stats only. All execute and write tools are hidden.
+- **full**: All 53 tools. Includes `komodo_write_resource` for creating, updating, and deleting Komodo resources.
+- **read-execute**: 52 tools. All read tools plus execute tools (deploy, pull, lifecycle, run, etc.). The `komodo_write_resource` tool is hidden.
+- **read-only**: 36 tools. List, get, logs, inspect, stats, summaries, and operation history only. All execute and write tools are hidden.
 
 Tools that are not available in your tier are not registered with the MCP server. They will not appear in your AI tool's tool list, keeping the context clean.
 
@@ -167,11 +167,11 @@ Generate API keys in the Komodo UI under **Settings > API Keys**.
 
 ### Available Categories
 
-`servers`, `stacks`, `deployments`, `containers`, `builds`, `repos`, `procedures`, `actions`, `builders`, `alerters`, `resource-syncs`, `write`
+`servers`, `stacks`, `deployments`, `containers`, `builds`, `repos`, `procedures`, `actions`, `builders`, `alerters`, `resource-syncs`, `updates`, `write`
 
 ## Tools
 
-mcp-komodo provides 46 tools organized by category. Each tool's Access column shows the minimum tier required: `read-only` (available in all tiers), `read-execute` (requires `read-execute` or `full`), or `full` (requires `full` tier only).
+mcp-komodo provides 53 tools organized by category. Each tool's Access column shows the minimum tier required: `read-only` (available in all tiers), `read-execute` (requires `read-execute` or `full`), or `full` (requires `full` tier only).
 
 <details>
 <summary>Servers (10 tools)</summary>
@@ -192,30 +192,35 @@ mcp-komodo provides 46 tools organized by category. Each tool's Access column sh
 </details>
 
 <details>
-<summary>Stacks (7 tools)</summary>
+<summary>Stacks (10 tools)</summary>
 
 | Tool | Description | Access |
 |------|-------------|--------|
 | `komodo_list_stacks` | List all stacks with state, server, and service count | read-only |
 | `komodo_get_stack` | Get stack configuration, services, and action state | read-only |
+| `komodo_list_stack_services` | List services in a stack with image, container state, and update availability | read-only |
+| `komodo_get_stacks_summary` | Get aggregate counts of all stacks by state | read-only |
 | `komodo_get_stack_log` | Get logs from stack services, with optional search | read-only |
 | `komodo_inspect_stack_container` | Inspect a container for a specific service in a stack | read-only |
 | `komodo_deploy_stack` | Deploy or redeploy a stack | read-execute |
+| `komodo_pull_stack` | Pull latest images without redeploying (docker compose pull) | read-execute |
 | `komodo_stack_lifecycle` | Start, stop, restart, pause, or unpause a stack | read-execute |
 | `komodo_destroy_stack` | Permanently destroy a stack | read-execute |
 
 </details>
 
 <details>
-<summary>Deployments (7 tools)</summary>
+<summary>Deployments (9 tools)</summary>
 
 | Tool | Description | Access |
 |------|-------------|--------|
 | `komodo_list_deployments` | List all deployments with state, image, and server | read-only |
 | `komodo_get_deployment` | Get deployment configuration, container status, and action state | read-only |
+| `komodo_get_deployments_summary` | Get aggregate counts of all deployments by state | read-only |
 | `komodo_get_deployment_log` | Get container logs, with optional search | read-only |
 | `komodo_inspect_deployment_container` | Inspect the container for a deployment (equivalent to docker inspect) | read-only |
 | `komodo_deploy_deployment` | Deploy with latest image and configuration | read-execute |
+| `komodo_pull_deployment` | Pull latest image without redeploying (docker pull) | read-execute |
 | `komodo_deployment_lifecycle` | Start, stop, restart, pause, or unpause a deployment | read-execute |
 | `komodo_destroy_deployment` | Permanently destroy a deployment | read-execute |
 
@@ -307,6 +312,16 @@ mcp-komodo provides 46 tools organized by category. Each tool's Access column sh
 </details>
 
 <details>
+<summary>Updates (2 tools)</summary>
+
+| Tool | Description | Access |
+|------|-------------|--------|
+| `komodo_list_updates` | List operation history with filters for resource type, target, operation, and success | read-only |
+| `komodo_get_update` | Get full operation details including logs with stdout/stderr for each stage | read-only |
+
+</details>
+
+<details>
 <summary>Write (1 tool)</summary>
 
 | Tool | Description | Access |
@@ -335,6 +350,10 @@ Once configured, ask your AI tool questions in natural language:
 
 - **"Deploy the frontend stack"** -- calls `komodo_deploy_stack` to redeploy the stack with its current configuration.
 
+- **"Why did the frontend stack deploy fail?"** -- calls `komodo_list_updates` to find the failed deploy, then `komodo_get_update` to show the full logs with stdout/stderr.
+
+- **"Pull the latest images for the monitoring stack"** -- calls `komodo_pull_stack` to download updated images without redeploying.
+
 - **"Create a new deployment called api-staging with image myapp:latest"** -- calls `komodo_write_resource` to create a new Deployment resource in Komodo.
 
 ## Troubleshooting
@@ -346,7 +365,7 @@ Check that `KOMODO_URL` is correct and that Komodo Core is reachable from where 
 Verify your API key and secret are correct. Check that the key has not been revoked or expired in the Komodo UI under Settings > API Keys.
 
 **Tools not showing up in your AI tool**
-Check your access tier setting. In `read-only` mode, only 31 tools are registered. In `read-execute` mode, 45 tools are registered. Use `full` (or omit `KOMODO_ACCESS_TIER`) for all 46 tools. Check `KOMODO_CATEGORIES` -- only tools in listed categories are registered. Also verify the server started without errors by checking stderr output.
+Check your access tier setting. In `read-only` mode, only 36 tools are registered. In `read-execute` mode, 52 tools are registered. Use `full` (or omit `KOMODO_ACCESS_TIER`) for all 53 tools. Check `KOMODO_CATEGORIES` -- only tools in listed categories are registered. Also verify the server started without errors by checking stderr output.
 
 **Node.js version errors**
 mcp-komodo requires Node.js >= 18.0.0. Check your version with `node --version`.

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -19,6 +19,7 @@ import { registerActionTools } from "./actions.js";
 import { registerBuilderTools } from "./builders.js";
 import { registerAlerterTools } from "./alerters.js";
 import { registerResourceSyncTools } from "./resource-syncs.js";
+import { registerUpdateTools } from "./updates.js";
 import { registerWriteTools } from "./write.js";
 
 export function registerAllTools(
@@ -37,5 +38,6 @@ export function registerAllTools(
   registerBuilderTools(server, client, config);
   registerAlerterTools(server, client, config);
   registerResourceSyncTools(server, client, config);
+  registerUpdateTools(server, client, config);
   registerWriteTools(server, client, config);
 }

--- a/src/tools/updates.ts
+++ b/src/tools/updates.ts
@@ -1,0 +1,143 @@
+/**
+ * Update domain tools: list updates, get update detail.
+ *
+ * Registers 2 MCP tools for Komodo Update (operation history) resources.
+ * An Update records the result of any execute operation (deploy, start,
+ * stop, build, etc.), including full command logs with stdout/stderr.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { createClient } from "../core/client.js";
+import type { AppConfig } from "../core/config.js";
+import { handleKomodoError } from "../core/errors.js";
+import {
+  formatUpdateList,
+  formatUpdateDetail,
+} from "../core/formatters.js";
+import { registerTool } from "../core/tools.js";
+
+type KomodoClient = ReturnType<typeof createClient>;
+
+export function registerUpdateTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
+  // -------------------------------------------------------------------------
+  // komodo_list_updates
+  // -------------------------------------------------------------------------
+  registerTool(server, config, {
+    name: "komodo_list_updates",
+    description:
+      "List Komodo operation history (updates). Every execute operation " +
+      "(deploy, start, stop, build, pull, etc.) creates an Update record. " +
+      "Filter by resource type, resource name/ID, operation, or success " +
+      "status. Returns operation, target, status, and timestamp for each " +
+      "update. Use komodo_get_update with an update ID to see full logs.",
+    accessTier: "read-only",
+    category: "updates",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+    },
+    inputSchema: {
+      target_type: z
+        .enum([
+          "Server", "Stack", "Deployment", "Build", "Repo",
+          "Procedure", "Action", "Builder", "Alerter", "ResourceSync",
+          "ServerTemplate",
+        ])
+        .optional()
+        .describe("Filter by resource type (e.g. 'Stack', 'Deployment')"),
+      target_id: z
+        .string()
+        .optional()
+        .describe("Filter by resource name or ID"),
+      operation: z
+        .string()
+        .optional()
+        .describe(
+          "Filter by operation name (e.g. 'DeployStack', 'Deploy', " +
+          "'RunBuild', 'StartStack', 'PullStack')",
+        ),
+      success: z
+        .boolean()
+        .optional()
+        .describe("Filter by success status (true = succeeded, false = failed)"),
+      page: z
+        .number()
+        .min(0)
+        .optional()
+        .describe(
+          "Page number for pagination (0 = most recent). Use the " +
+          "next_page value from a previous response to get more results.",
+        ),
+    },
+    handler: async (args) => {
+      const target_type = args.target_type as string | undefined;
+      const target_id = args.target_id as string | undefined;
+      const operation = args.operation as string | undefined;
+      const success = args.success as boolean | undefined;
+      const page = args.page as number | undefined;
+      try {
+        const query: Record<string, unknown> = {};
+        if (target_type) query["target.type"] = target_type;
+        if (target_id) query["target.id"] = target_id;
+        if (operation) query["operation"] = operation;
+        if (success !== undefined) query["success"] = success;
+
+        const response = await client.read("ListUpdates", {
+          query: Object.keys(query).length > 0 ? query : undefined,
+          page: page ?? 0,
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: formatUpdateList(response.updates, response.next_page),
+            },
+          ],
+        };
+      } catch (error) {
+        return handleKomodoError("listing updates", error);
+      }
+    },
+  });
+
+  // -------------------------------------------------------------------------
+  // komodo_get_update
+  // -------------------------------------------------------------------------
+  registerTool(server, config, {
+    name: "komodo_get_update",
+    description:
+      "Get detailed information about a specific Komodo Update (operation " +
+      "record) by ID. Returns the full operation details including status, " +
+      "success/failure, operator, timestamps, and complete execution logs " +
+      "with stdout/stderr for each stage. Use this to check deploy results, " +
+      "diagnose failures, or monitor in-progress operations.",
+    accessTier: "read-only",
+    category: "updates",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+    },
+    inputSchema: {
+      id: z.string().describe("Update ID (returned by execute operations or komodo_list_updates)"),
+    },
+    handler: async (args) => {
+      const id = args.id as string;
+      try {
+        const update = await client.read("GetUpdate", { id });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: formatUpdateDetail(update),
+            },
+          ],
+        };
+      } catch (error) {
+        return handleKomodoError(`getting update '${id}'`, error);
+      }
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Adds 7 new MCP tools (46 → 53) across 3 categories, filling gaps in the Komodo SDK coverage:

**Updates (new category — 2 tools):**
- `komodo_list_updates` — list operation history with typed filters (target_type, target_id, operation, success, page). Builds MongoDB queries internally from named parameters.
- `komodo_get_update` — get full update detail including all log stages with stdout/stderr. Enables diagnosing deploy failures without accessing the Komodo UI.

**Stacks (3 new tools, 7 → 10):**
- `komodo_list_stack_services` — list services in a stack with image, container state, and update availability (read-only)
- `komodo_get_stacks_summary` — aggregate counts by state across all stacks (read-only)
- `komodo_pull_stack` — pull latest images without redeploying, with optional service filter (read-execute)

**Deployments (2 new tools, 7 → 9):**
- `komodo_get_deployments_summary` — aggregate counts by state across all deployments (read-only)
- `komodo_pull_deployment` — pull latest image without redeploying (read-execute)

**Files changed:**
- `src/tools/updates.ts` — new file with 2 tools
- `src/tools/stacks.ts` — 3 new tool registrations
- `src/tools/deployments.ts` — 2 new tool registrations
- `src/core/formatters.ts` — 5 new formatters (`formatUpdateList`, `formatUpdateDetail`, `formatStackServiceList`, `formatStacksSummary`, `formatDeploymentsSummary`), removed stale empty comment block
- `src/tools/index.ts` — wired `registerUpdateTools`
- `README.md` — updated tool counts (53/13), tier counts (36/52/53), added Updates section, new tool rows in Stacks/Deployments tables, new usage examples, updated troubleshooting