### PR TITLE
chore: bump @modelcontextprotocol/sdk to ^1.27.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.26.0",
+        "@modelcontextprotocol/sdk": "^1.27.1",
         "komodo_client": "^1.19.5",
         "zod": "^3.25.0"
       },
@@ -487,9 +487,9 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "komodo_client": "^1.19.5",
     "zod": "^3.25.0"
   },


### PR DESCRIPTION
## Summary

- Bump `@modelcontextprotocol/sdk` from `^1.26.0` to `^1.27.1` (latest stable)
- Updates both `package.json` dependency specifier and `package-lock.json` resolved version

## What changed in SDK v1.27.1

- Fix: silently swallowed transport errors now properly call `onerror` handler
- OAuth discovery caching (`discoverOAuthServerInfo()`)
- `url` property on `RequestInfo` interface
- Streaming methods for elicitation and sampling in experimental tasks API
- Command injection prevention fix in example URL opening
- Conformance test infrastructure

## Verification

- All packages build cleanly (`npm run build`)
- All tests pass (`npm test`)
- Live MCP tool calls verified against all 4 servers (17/17 passed)