### PR TITLE
feat: replace GPL komodo_client SDK with native fetch client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "komodo_client": "^1.19.5",
         "zod": "^3.25.0"
       },
       "bin": {
@@ -1797,12 +1796,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
-    },
-    "node_modules/komodo_client": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/komodo_client/-/komodo_client-1.19.5.tgz",
-      "integrity": "sha512-cavOe3Y9wpx2wNgF2f5NyK2c+ndwUaXx16v4IK7IxCyM71YH8kNaRJdgYkFpouxjKWLWbP/bhv8cI7Dznl76Ow==",
-      "license": "GPL-3.0"
     },
     "node_modules/loupe": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "komodo_client": "^1.19.5",
     "zod": "^3.25.0"
   },
   "devDependencies": {

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -1,44 +1,159 @@
 /**
- * Komodo API client factory with startup validation.
+ * Komodo API client using native fetch.
  *
- * CRITICAL: KomodoClient is a FACTORY FUNCTION -- do NOT use `new`.
- * Sensitive patterns are registered BEFORE the client is created
- * so that any error during initialization is also sanitized.
+ * Replaces the komodo_client SDK with a minimal HTTP wrapper.
+ * The Komodo Core API uses a uniform pattern:
+ *   POST /{category}/{operation}  with JSON body
+ *
+ * Categories: /read, /write, /execute
+ * Auth: x-api-key + x-api-secret headers
  */
 
-import { KomodoClient } from "komodo_client";
 import type { AppConfig } from "./config.js";
+import { KomodoError, registerSensitivePattern, sanitizeMessage } from "./errors.js";
 import { logger } from "./logger.js";
-import { registerSensitivePattern, sanitizeMessage } from "./errors.js";
+
+/** Request timeout in milliseconds. */
+const REQUEST_TIMEOUT_MS = 30_000;
+
+export class KomodoClient {
+  private readonly baseUrl: string;
+  private readonly headers: Record<string, string>;
+
+  constructor(config: AppConfig) {
+    this.baseUrl = config.url;
+    this.headers = {
+      "x-api-key": config.apiKey,
+      "x-api-secret": config.apiSecret,
+      "content-type": "application/json",
+    };
+  }
+
+  /** Call the /read API — queries and reads (no side effects). */
+  async read(operation: string, params: object): Promise<any> {
+    return this.request("/read", operation, params);
+  }
+
+  /** Call the /write API — create, update, delete resources. */
+  async write(operation: string, params: object): Promise<any> {
+    return this.request("/write", operation, params);
+  }
+
+  /** Call the /execute API — trigger operations (deploy, build, etc.). */
+  async execute(operation: string, params: object): Promise<any> {
+    return this.request("/execute", operation, params);
+  }
+
+  /**
+   * Validate connectivity by calling GetVersion.
+   * Logs the Komodo version on success.
+   */
+  async validateConnection(): Promise<void> {
+    const url = `${this.baseUrl}/read/GetVersion`;
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: this.headers,
+        body: JSON.stringify({}),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+
+      if (response.status === 401 || response.status === 403) {
+        throw new KomodoError(
+          "Authentication failed -- check KOMODO_API_KEY and KOMODO_API_SECRET",
+          response.status,
+        );
+      }
+
+      if (!response.ok) {
+        throw new KomodoError(
+          `Connection check failed: ${response.status} ${response.statusText}`,
+          response.status,
+        );
+      }
+
+      const data = await response.json() as { version?: string };
+      logger.info(
+        `Connected to Komodo at ${this.baseUrl} (version: ${data.version ?? "unknown"})`,
+      );
+    } catch (err) {
+      if (err instanceof KomodoError) throw err;
+      throw new KomodoError(
+        sanitizeMessage(
+          `Cannot connect to Komodo at ${this.baseUrl}: ${err instanceof Error ? err.message : String(err)}`,
+        ),
+      );
+    }
+  }
+
+  /**
+   * Core request method. Sends POST to /{category}/{operation} with
+   * JSON body, checks for errors, and returns parsed response.
+   */
+  private async request(
+    category: string,
+    operation: string,
+    params: object,
+  ): Promise<any> {
+    const url = `${this.baseUrl}${category}/${operation}`;
+
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: this.headers,
+        body: JSON.stringify(params),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+
+      if (!response.ok) {
+        let detail = `${response.status} ${response.statusText}`;
+        try {
+          const errBody = await response.json() as { error?: string };
+          if (errBody.error) {
+            detail += ` — ${errBody.error}`;
+          }
+        } catch {
+          // Ignore JSON parse failures on error bodies
+        }
+        throw new KomodoError(
+          sanitizeMessage(`${operation} failed: ${detail}`),
+          response.status,
+        );
+      }
+
+      return await response.json();
+    } catch (err) {
+      if (err instanceof KomodoError) throw err;
+      throw new KomodoError(
+        sanitizeMessage(
+          err instanceof Error ? err.message : String(err),
+        ),
+      );
+    }
+  }
+}
 
 /**
  * Create a Komodo API client from config.
  * Registers credentials as sensitive patterns before creating the client.
  */
-export function createClient(config: AppConfig) {
+export function createClient(config: AppConfig): KomodoClient {
   registerSensitivePattern(config.apiKey);
   registerSensitivePattern(config.apiSecret);
-
-  return KomodoClient(config.url, {
-    type: "api-key",
-    params: { key: config.apiKey, secret: config.apiSecret },
-  });
+  return new KomodoClient(config);
 }
 
 /**
- * Validate connectivity to Komodo by calling GetVersion.
+ * Validate connectivity to Komodo.
  * Must be called during startup before accepting MCP connections.
  * Exits the process with code 1 if validation fails.
  */
 export async function validateConnection(
-  client: ReturnType<typeof createClient>,
+  client: KomodoClient,
   config: AppConfig,
 ): Promise<void> {
   try {
-    const version = await client.read("GetVersion", {});
-    logger.info(
-      `Connected to Komodo at ${config.url} (version: ${version.version})`,
-    );
+    await client.validateConnection();
   } catch (error) {
     logger.error(`Failed to connect to Komodo at ${config.url}`);
     logger.error(

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -45,6 +45,20 @@ export function sanitizeMessage(message: string): string {
   return sanitized;
 }
 
+/**
+ * Custom error class for Komodo API errors with optional HTTP status code.
+ * Consistent with AdGuardError / PveError in the other MCP servers.
+ */
+export class KomodoError extends Error {
+  public readonly statusCode?: number;
+
+  constructor(message: string, statusCode?: number) {
+    super(message);
+    this.name = "KomodoError";
+    this.statusCode = statusCode;
+  }
+}
+
 /** MCP-compliant error response type with isError flag. */
 export type McpErrorResponse = {
   content: Array<{ type: "text"; text: string }>;

--- a/src/core/formatters.ts
+++ b/src/core/formatters.ts
@@ -6,7 +6,46 @@
  * Details show key fields only, not every config option.
  */
 
-import { Types } from "komodo_client";
+import type {
+  ServerListItem,
+  Server,
+  ServerActionState,
+  SystemStats,
+  SystemInformation,
+  SystemProcess,
+  StackListItem,
+  Stack,
+  StackActionState,
+  StackService,
+  GetStacksSummaryResponse,
+  DeploymentListItem,
+  Deployment,
+  DeploymentActionState,
+  GetDeploymentsSummaryResponse,
+  BuildListItem,
+  Build,
+  BuildActionState,
+  RepoListItem,
+  Repo,
+  RepoActionState,
+  ProcedureListItem,
+  Procedure,
+  ProcedureActionState,
+  ActionListItem,
+  Action,
+  ActionActionState,
+  BuilderListItem,
+  Builder,
+  AlerterListItem,
+  Alerter,
+  ResourceSyncListItem,
+  ResourceSync,
+  ResourceSyncActionState,
+  UpdateListItem,
+  Update,
+  Log,
+  Version,
+} from "../types/komodo.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -17,7 +56,7 @@ function formatTags(tags?: string[]): string {
   return `\nTags: ${tags.join(", ")}`;
 }
 
-function formatVersion(v?: Types.Version): string {
+function formatVersion(v?: Version): string {
   if (!v) return "0.0.0";
   return `${v.major}.${v.minor}.${v.patch}`;
 }
@@ -41,7 +80,7 @@ function formatActionState(
 // Server formatters
 // ---------------------------------------------------------------------------
 
-export function formatServerList(servers: Types.ServerListItem[]): string {
+export function formatServerList(servers: ServerListItem[]): string {
   if (servers.length === 0) return "No servers found.";
   const lines = servers.map(
     (s) =>
@@ -51,8 +90,8 @@ export function formatServerList(servers: Types.ServerListItem[]): string {
 }
 
 export function formatServerDetail(
-  server: Types.Server,
-  actionState?: Types.ServerActionState,
+  server: Server,
+  actionState?: ServerActionState,
 ): string {
   const sections: string[] = [
     `Name: ${server.name}`,
@@ -75,7 +114,7 @@ export function formatServerDetail(
   return sections.filter(Boolean).join("\n");
 }
 
-export function formatSystemStats(stats: Types.SystemStats): string {
+export function formatSystemStats(stats: SystemStats): string {
   const memPct =
     stats.mem_total_gb > 0
       ? ((stats.mem_used_gb / stats.mem_total_gb) * 100).toFixed(0)
@@ -101,7 +140,7 @@ export function formatSystemStats(stats: Types.SystemStats): string {
   return lines.join("\n");
 }
 
-export function formatSystemInfo(info: Types.SystemInformation): string {
+export function formatSystemInfo(info: SystemInformation): string {
   const lines: string[] = [];
   if (info.host_name) lines.push(`Hostname: ${info.host_name}`);
   if (info.os) lines.push(`OS: ${info.os}`);
@@ -111,7 +150,7 @@ export function formatSystemInfo(info: Types.SystemInformation): string {
   return lines.join("\n");
 }
 
-export function formatProcessList(processes: Types.SystemProcess[]): string {
+export function formatProcessList(processes: SystemProcess[]): string {
   if (processes.length === 0) return "No processes found.";
   const sorted = [...processes]
     .sort((a, b) => b.cpu_perc - a.cpu_perc)
@@ -128,7 +167,7 @@ export function formatProcessList(processes: Types.SystemProcess[]): string {
 // Stack formatters
 // ---------------------------------------------------------------------------
 
-export function formatStackList(stacks: Types.StackListItem[]): string {
+export function formatStackList(stacks: StackListItem[]): string {
   if (stacks.length === 0) return "No stacks found.";
   const lines = stacks.map(
     (s) =>
@@ -138,8 +177,8 @@ export function formatStackList(stacks: Types.StackListItem[]): string {
 }
 
 export function formatStackDetail(
-  stack: Types.Stack,
-  actionState?: Types.StackActionState,
+  stack: Stack,
+  actionState?: StackActionState,
 ): string {
   const sections: string[] = [
     `Name: ${stack.name}`,
@@ -173,7 +212,7 @@ export function formatStackDetail(
 // ---------------------------------------------------------------------------
 
 export function formatDeploymentList(
-  deployments: Types.DeploymentListItem[],
+  deployments: DeploymentListItem[],
 ): string {
   if (deployments.length === 0) return "No deployments found.";
   const lines = deployments.map(
@@ -184,8 +223,8 @@ export function formatDeploymentList(
 }
 
 export function formatDeploymentDetail(
-  deployment: Types.Deployment,
-  actionState?: Types.DeploymentActionState,
+  deployment: Deployment,
+  actionState?: DeploymentActionState,
 ): string {
   const sections: string[] = [
     `Name: ${deployment.name}`,
@@ -218,7 +257,7 @@ export function formatDeploymentDetail(
 // Build formatters
 // ---------------------------------------------------------------------------
 
-export function formatBuildList(builds: Types.BuildListItem[]): string {
+export function formatBuildList(builds: BuildListItem[]): string {
   if (builds.length === 0) return "No builds found.";
   const lines = builds.map(
     (b) =>
@@ -228,8 +267,8 @@ export function formatBuildList(builds: Types.BuildListItem[]): string {
 }
 
 export function formatBuildDetail(
-  build: Types.Build,
-  actionState?: Types.BuildActionState,
+  build: Build,
+  actionState?: BuildActionState,
 ): string {
   const sections: string[] = [
     `Name: ${build.name}`,
@@ -261,7 +300,7 @@ export function formatBuildDetail(
 // Repo formatters
 // ---------------------------------------------------------------------------
 
-export function formatRepoList(repos: Types.RepoListItem[]): string {
+export function formatRepoList(repos: RepoListItem[]): string {
   if (repos.length === 0) return "No repos found.";
   const lines = repos.map(
     (r) =>
@@ -271,8 +310,8 @@ export function formatRepoList(repos: Types.RepoListItem[]): string {
 }
 
 export function formatRepoDetail(
-  repo: Types.Repo,
-  actionState?: Types.RepoActionState,
+  repo: Repo,
+  actionState?: RepoActionState,
 ): string {
   const sections: string[] = [
     `Name: ${repo.name}`,
@@ -305,7 +344,7 @@ export function formatRepoDetail(
 // ---------------------------------------------------------------------------
 
 export function formatProcedureList(
-  procedures: Types.ProcedureListItem[],
+  procedures: ProcedureListItem[],
 ): string {
   if (procedures.length === 0) return "No procedures found.";
   const lines = procedures.map(
@@ -316,8 +355,8 @@ export function formatProcedureList(
 }
 
 export function formatProcedureDetail(
-  procedure: Types.Procedure,
-  actionState?: Types.ProcedureActionState,
+  procedure: Procedure,
+  actionState?: ProcedureActionState,
 ): string {
   const sections: string[] = [
     `Name: ${procedure.name}`,
@@ -346,7 +385,7 @@ export function formatProcedureDetail(
 // Action formatters
 // ---------------------------------------------------------------------------
 
-export function formatActionList(actions: Types.ActionListItem[]): string {
+export function formatActionList(actions: ActionListItem[]): string {
   if (actions.length === 0) return "No actions found.";
   const lines = actions.map(
     (a) =>
@@ -356,8 +395,8 @@ export function formatActionList(actions: Types.ActionListItem[]): string {
 }
 
 export function formatActionDetail(
-  action: Types.Action,
-  actionState?: Types.ActionActionState,
+  action: Action,
+  actionState?: ActionActionState,
 ): string {
   const sections: string[] = [
     `Name: ${action.name}`,
@@ -381,7 +420,7 @@ export function formatActionDetail(
 // Builder formatters
 // ---------------------------------------------------------------------------
 
-export function formatBuilderList(builders: Types.BuilderListItem[]): string {
+export function formatBuilderList(builders: BuilderListItem[]): string {
   if (builders.length === 0) return "No builders found.";
   const lines = builders.map(
     (b) =>
@@ -391,7 +430,7 @@ export function formatBuilderList(builders: Types.BuilderListItem[]): string {
 }
 
 export function formatBuilderDetail(
-  builder: Types.Builder,
+  builder: Builder,
   actionState?: Record<string, boolean>,
 ): string {
   const sections: string[] = [
@@ -421,7 +460,7 @@ export function formatBuilderDetail(
 // Alerter formatters
 // ---------------------------------------------------------------------------
 
-export function formatAlerterList(alerters: Types.AlerterListItem[]): string {
+export function formatAlerterList(alerters: AlerterListItem[]): string {
   if (alerters.length === 0) return "No alerters found.";
   const lines = alerters.map(
     (a) =>
@@ -430,7 +469,7 @@ export function formatAlerterList(alerters: Types.AlerterListItem[]): string {
   return `Found ${alerters.length} alerter(s):\n${lines.join("\n")}`;
 }
 
-export function formatAlerterDetail(alerter: Types.Alerter): string {
+export function formatAlerterDetail(alerter: Alerter): string {
   const sections: string[] = [
     `Name: ${alerter.name}`,
     `ID: ${alerter._id?.$oid ?? "unknown"}`,
@@ -450,7 +489,7 @@ export function formatAlerterDetail(alerter: Types.Alerter): string {
 // ---------------------------------------------------------------------------
 
 export function formatResourceSyncList(
-  syncs: Types.ResourceSyncListItem[],
+  syncs: ResourceSyncListItem[],
 ): string {
   if (syncs.length === 0) return "No resource syncs found.";
   const lines = syncs.map(
@@ -461,8 +500,8 @@ export function formatResourceSyncList(
 }
 
 export function formatResourceSyncDetail(
-  sync: Types.ResourceSync,
-  actionState?: Types.ResourceSyncActionState,
+  sync: ResourceSync,
+  actionState?: ResourceSyncActionState,
 ): string {
   const sections: string[] = [
     `Name: ${sync.name}`,
@@ -495,7 +534,7 @@ export function formatResourceSyncDetail(
 // ---------------------------------------------------------------------------
 
 export function formatStackServiceList(
-  services: Types.StackService[],
+  services: StackService[],
 ): string {
   if (services.length === 0) return "No services found in this stack.";
   const lines = services.map((s) => {
@@ -518,7 +557,7 @@ export function formatStackServiceList(
 // ---------------------------------------------------------------------------
 
 export function formatStacksSummary(
-  summary: Types.GetStacksSummaryResponse,
+  summary: GetStacksSummaryResponse,
 ): string {
   const lines: string[] = [
     `Stacks summary:`,
@@ -533,7 +572,7 @@ export function formatStacksSummary(
 }
 
 export function formatDeploymentsSummary(
-  summary: Types.GetDeploymentsSummaryResponse,
+  summary: GetDeploymentsSummaryResponse,
 ): string {
   const lines: string[] = [
     `Deployments summary:`,
@@ -552,7 +591,7 @@ export function formatDeploymentsSummary(
 // ---------------------------------------------------------------------------
 
 export function formatUpdateList(
-  updates: Types.UpdateListItem[],
+  updates: UpdateListItem[],
   nextPage?: number,
 ): string {
   if (updates.length === 0) return "No updates found.";
@@ -569,7 +608,7 @@ export function formatUpdateList(
   return text;
 }
 
-export function formatUpdateDetail(update: Types.Update): string {
+export function formatUpdateDetail(update: Update): string {
   const sections: string[] = [
     `Operation: ${update.operation}`,
     `Target: ${update.target.type}/${update.target.id}`,
@@ -598,7 +637,7 @@ export function formatUpdateDetail(update: Types.Update): string {
 // Log formatter
 // ---------------------------------------------------------------------------
 
-export function formatLog(log: Types.Log): string {
+export function formatLog(log: Log): string {
   const output = log.stdout || log.stderr || "(no output)";
   const header = `[${log.success ? "OK" : "FAILED"}] ${log.stage}`;
   return `${header}\n${output}`;
@@ -653,7 +692,7 @@ export function formatResourceDeleted(
 // ---------------------------------------------------------------------------
 
 export function formatUpdateCreated(
-  update: Types.Update,
+  update: Update,
   description: string,
 ): string {
   const updateId = update._id?.$oid ?? "unknown";

--- a/src/tests/handlers.test.ts
+++ b/src/tests/handlers.test.ts
@@ -2,10 +2,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { createServer } from "../core/server.js";
 import { registerAllTools } from "../tools/index.js";
 import { makeConfig, makeMockClient, connectTestClient } from "./helpers.js";
-import type { createClient } from "../core/client.js";
+import type { KomodoClient } from "../core/client.js";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
-
-type KomodoClient = ReturnType<typeof createClient>;
 
 describe("handler: komodo_list_servers", () => {
   let cleanup: () => Promise<void>;

--- a/src/tests/helpers.ts
+++ b/src/tests/helpers.ts
@@ -3,9 +3,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { AppConfig } from "../core/config.js";
-import type { createClient } from "../core/client.js";
-
-type KomodoClient = ReturnType<typeof createClient>;
+import type { KomodoClient } from "../core/client.js";
 
 export function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
   return {

--- a/src/tools/actions.ts
+++ b/src/tools/actions.ts
@@ -7,7 +7,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { createClient } from "../core/client.js";
+import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
 import {
@@ -16,8 +16,6 @@ import {
   formatUpdateCreated,
 } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
-
-type KomodoClient = ReturnType<typeof createClient>;
 
 export function registerActionTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
   // -------------------------------------------------------------------------

--- a/src/tools/alerters.ts
+++ b/src/tools/alerters.ts
@@ -8,13 +8,11 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { createClient } from "../core/client.js";
+import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
 import { formatAlerterList, formatAlerterDetail } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
-
-type KomodoClient = ReturnType<typeof createClient>;
 
 export function registerAlerterTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
   // -------------------------------------------------------------------------

--- a/src/tools/builders.ts
+++ b/src/tools/builders.ts
@@ -8,13 +8,11 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { createClient } from "../core/client.js";
+import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
 import { formatBuilderList, formatBuilderDetail } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
-
-type KomodoClient = ReturnType<typeof createClient>;
 
 export function registerBuilderTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
   // -------------------------------------------------------------------------

--- a/src/tools/builds.ts
+++ b/src/tools/builds.ts
@@ -8,7 +8,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { createClient } from "../core/client.js";
+import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
 import {
@@ -17,8 +17,6 @@ import {
   formatUpdateCreated,
 } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
-
-type KomodoClient = ReturnType<typeof createClient>;
 
 export function registerBuildTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
   // -------------------------------------------------------------------------

--- a/src/tools/containers.ts
+++ b/src/tools/containers.ts
@@ -8,14 +8,12 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { Types } from "komodo_client";
-import type { createClient } from "../core/client.js";
+import { SearchCombinator } from "../types/komodo.js";
+import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
 import { formatLog } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
-
-type KomodoClient = ReturnType<typeof createClient>;
 
 export function registerContainerTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
   // -------------------------------------------------------------------------
@@ -69,7 +67,7 @@ export function registerContainerTools(server: McpServer, client: KomodoClient, 
             server: serverParam,
             container,
             terms: search_terms,
-            combinator: (search_combinator as Types.SearchCombinator) || Types.SearchCombinator.Or,
+            combinator: (search_combinator as SearchCombinator) || SearchCombinator.Or,
           });
         } else {
           log = await client.read("GetContainerLog", {

--- a/src/tools/deployments.ts
+++ b/src/tools/deployments.ts
@@ -9,8 +9,8 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { Types } from "komodo_client";
-import type { createClient } from "../core/client.js";
+import { SearchCombinator } from "../types/komodo.js";
+import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
 import {
@@ -21,8 +21,6 @@ import {
   formatUpdateCreated,
 } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
-
-type KomodoClient = ReturnType<typeof createClient>;
 
 export function registerDeploymentTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
   // -------------------------------------------------------------------------
@@ -155,7 +153,7 @@ export function registerDeploymentTools(server: McpServer, client: KomodoClient,
           log = await client.read("SearchDeploymentLog", {
             deployment,
             terms: search_terms,
-            combinator: (search_combinator as Types.SearchCombinator) || Types.SearchCombinator.Or,
+            combinator: (search_combinator as SearchCombinator) || SearchCombinator.Or,
           });
         } else {
           log = await client.read("GetDeploymentLog", {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,7 +6,7 @@
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { createClient } from "../core/client.js";
+import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { registerServerTools } from "./servers.js";
 import { registerStackTools } from "./stacks.js";
@@ -24,7 +24,7 @@ import { registerWriteTools } from "./write.js";
 
 export function registerAllTools(
   server: McpServer,
-  client: ReturnType<typeof createClient>,
+  client: KomodoClient,
   config: AppConfig,
 ): void {
   registerServerTools(server, client, config);

--- a/src/tools/procedures.ts
+++ b/src/tools/procedures.ts
@@ -8,7 +8,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { createClient } from "../core/client.js";
+import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
 import {
@@ -17,8 +17,6 @@ import {
   formatUpdateCreated,
 } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
-
-type KomodoClient = ReturnType<typeof createClient>;
 
 export function registerProcedureTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
   // -------------------------------------------------------------------------

--- a/src/tools/repos.ts
+++ b/src/tools/repos.ts
@@ -8,7 +8,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { createClient } from "../core/client.js";
+import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
 import {
@@ -17,8 +17,6 @@ import {
   formatUpdateCreated,
 } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
-
-type KomodoClient = ReturnType<typeof createClient>;
 
 export function registerRepoTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
   // -------------------------------------------------------------------------

--- a/src/tools/resource-syncs.ts
+++ b/src/tools/resource-syncs.ts
@@ -8,7 +8,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { createClient } from "../core/client.js";
+import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
 import {
@@ -17,8 +17,6 @@ import {
   formatUpdateCreated,
 } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
-
-type KomodoClient = ReturnType<typeof createClient>;
 
 export function registerResourceSyncTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
   // -------------------------------------------------------------------------

--- a/src/tools/servers.ts
+++ b/src/tools/servers.ts
@@ -7,7 +7,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { createClient } from "../core/client.js";
+import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
 import {
@@ -19,8 +19,6 @@ import {
   formatUpdateCreated,
 } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
-
-type KomodoClient = ReturnType<typeof createClient>;
 
 export function registerServerTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
   // -------------------------------------------------------------------------

--- a/src/tools/stacks.ts
+++ b/src/tools/stacks.ts
@@ -9,8 +9,8 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { Types } from "komodo_client";
-import type { createClient } from "../core/client.js";
+import { SearchCombinator } from "../types/komodo.js";
+import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
 import {
@@ -22,8 +22,6 @@ import {
   formatUpdateCreated,
 } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
-
-type KomodoClient = ReturnType<typeof createClient>;
 
 export function registerStackTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
   // -------------------------------------------------------------------------
@@ -159,7 +157,7 @@ export function registerStackTools(server: McpServer, client: KomodoClient, conf
             stack,
             services: services || [],
             terms: search_terms,
-            combinator: (search_combinator as Types.SearchCombinator) || Types.SearchCombinator.Or,
+            combinator: (search_combinator as SearchCombinator) || SearchCombinator.Or,
           });
         } else {
           log = await client.read("GetStackLog", {

--- a/src/tools/updates.ts
+++ b/src/tools/updates.ts
@@ -8,7 +8,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { createClient } from "../core/client.js";
+import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
 import {
@@ -16,8 +16,6 @@ import {
   formatUpdateDetail,
 } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
-
-type KomodoClient = ReturnType<typeof createClient>;
 
 export function registerUpdateTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
   // -------------------------------------------------------------------------

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -8,7 +8,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { createClient } from "../core/client.js";
+import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
 import {
@@ -17,8 +17,6 @@ import {
   formatResourceDeleted,
 } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
-
-type KomodoClient = ReturnType<typeof createClient>;
 
 // ---------------------------------------------------------------------------
 // Operation dispatch maps

--- a/src/types/komodo.ts
+++ b/src/types/komodo.ts
@@ -1,0 +1,473 @@
+/**
+ * Cherry-picked Komodo API types.
+ *
+ * These interfaces describe the JSON shapes returned by the Komodo Core
+ * REST API. They are structural type definitions for interoperability —
+ * only the subset actually consumed by this MCP server is included.
+ *
+ * Source reference: komodo_client v1.19.5 types.d.ts (auto-generated
+ * from the Rust backend via typeshare).
+ */
+
+// ---------------------------------------------------------------------------
+// Primitives
+// ---------------------------------------------------------------------------
+
+export interface MongoId {
+  $oid: string;
+}
+
+export interface Version {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+export interface ResourceTarget {
+  type: string;
+  id: string;
+}
+
+export enum SearchCombinator {
+  Or = "Or",
+  And = "And",
+}
+
+// ---------------------------------------------------------------------------
+// Base resource types
+// ---------------------------------------------------------------------------
+
+export interface Resource<Config, Info> {
+  _id?: MongoId;
+  name: string;
+  description?: string;
+  tags?: string[];
+  config?: Config;
+  info?: Info;
+}
+
+export interface ResourceListItem<Info> {
+  id: string;
+  type: string;
+  name: string;
+  tags: string[];
+  info: Info;
+}
+
+// ---------------------------------------------------------------------------
+// Server
+// ---------------------------------------------------------------------------
+
+export interface ServerConfig {
+  address: string;
+  region?: string;
+  enabled: boolean;
+  stats_monitoring: boolean;
+  auto_prune: boolean;
+}
+
+export interface ServerActionState {
+  pruning_networks: boolean;
+  pruning_containers: boolean;
+  pruning_images: boolean;
+  pruning_volumes: boolean;
+  pruning_builders: boolean;
+  pruning_buildx: boolean;
+  pruning_system: boolean;
+  starting_containers: boolean;
+  restarting_containers: boolean;
+  pausing_containers: boolean;
+  unpausing_containers: boolean;
+  stopping_containers: boolean;
+}
+
+export interface ServerListItemInfo {
+  state: string;
+  region: string;
+  address: string;
+}
+
+export type Server = Resource<ServerConfig, undefined>;
+export type ServerListItem = ResourceListItem<ServerListItemInfo>;
+
+// ---------------------------------------------------------------------------
+// System stats
+// ---------------------------------------------------------------------------
+
+export interface SystemLoadAverage {
+  one: number;
+  five: number;
+  fifteen: number;
+}
+
+export interface SingleDiskUsage {
+  mount: string;
+  used_gb: number;
+  total_gb: number;
+}
+
+export interface SystemStats {
+  cpu_perc: number;
+  load_average?: SystemLoadAverage;
+  mem_used_gb: number;
+  mem_total_gb: number;
+  disks: SingleDiskUsage[];
+}
+
+export interface SystemInformation {
+  name?: string;
+  os?: string;
+  kernel?: string;
+  core_count?: number;
+  host_name?: string;
+  cpu_brand: string;
+}
+
+export interface SystemProcess {
+  pid: number;
+  name: string;
+  cpu_perc: number;
+  mem_mb: number;
+}
+
+// ---------------------------------------------------------------------------
+// Stack
+// ---------------------------------------------------------------------------
+
+export interface StackConfig {
+  server_id?: string;
+  repo?: string;
+  git_provider: string;
+  branch: string;
+  auto_pull: boolean;
+  webhook_enabled: boolean;
+}
+
+export interface StackInfo {
+  deployed_project_name?: string;
+  deployed_hash?: string;
+  latest_hash?: string;
+}
+
+export interface StackActionState {
+  pulling: boolean;
+  deploying: boolean;
+  starting: boolean;
+  restarting: boolean;
+  pausing: boolean;
+  unpausing: boolean;
+  stopping: boolean;
+  destroying: boolean;
+}
+
+export interface ContainerListItem {
+  name: string;
+  state: string;
+  status?: string;
+}
+
+export interface StackService {
+  service: string;
+  image: string;
+  container?: ContainerListItem;
+  update_available: boolean;
+}
+
+export interface StackListItemInfo {
+  server_id: string;
+  state: string;
+  services?: { service: string; image: string; update_available: boolean }[];
+}
+
+export type Stack = Resource<StackConfig, StackInfo>;
+export type StackListItem = ResourceListItem<StackListItemInfo>;
+
+export interface GetStacksSummaryResponse {
+  total: number;
+  running: number;
+  stopped: number;
+  down: number;
+  unhealthy: number;
+  unknown: number;
+}
+
+// ---------------------------------------------------------------------------
+// Deployment
+// ---------------------------------------------------------------------------
+
+export interface DeploymentImage {
+  type: string;
+  params: Record<string, string>;
+}
+
+export interface DeploymentConfig {
+  server_id?: string;
+  image?: DeploymentImage;
+  network: string;
+  restart?: string;
+  redeploy_on_build?: boolean;
+}
+
+export interface DeploymentActionState {
+  pulling: boolean;
+  deploying: boolean;
+  starting: boolean;
+  restarting: boolean;
+  pausing: boolean;
+  unpausing: boolean;
+  stopping: boolean;
+  destroying: boolean;
+  renaming: boolean;
+}
+
+export interface DeploymentListItemInfo {
+  state: string;
+  image: string;
+  server_id: string;
+}
+
+export type Deployment = Resource<DeploymentConfig, undefined>;
+export type DeploymentListItem = ResourceListItem<DeploymentListItemInfo>;
+
+export interface GetDeploymentsSummaryResponse {
+  total: number;
+  running: number;
+  stopped: number;
+  not_deployed: number;
+  unhealthy: number;
+  unknown: number;
+}
+
+// ---------------------------------------------------------------------------
+// Build
+// ---------------------------------------------------------------------------
+
+export interface BuildConfig {
+  builder_id?: string;
+  version?: Version;
+  repo?: string;
+  git_provider: string;
+  branch: string;
+  build_path: string;
+  dockerfile_path: string;
+}
+
+export interface BuildInfo {
+  last_built_at: number;
+  built_hash?: string;
+  latest_hash?: string;
+}
+
+export interface BuildActionState {
+  building: boolean;
+}
+
+export interface BuildListItemInfo {
+  state: string;
+  version: Version;
+  repo?: string;
+}
+
+export type Build = Resource<BuildConfig, BuildInfo>;
+export type BuildListItem = ResourceListItem<BuildListItemInfo>;
+
+// ---------------------------------------------------------------------------
+// Repo
+// ---------------------------------------------------------------------------
+
+export interface SystemCommand {
+  path?: string;
+  command?: string;
+}
+
+export interface RepoConfig {
+  server_id?: string;
+  repo?: string;
+  git_provider: string;
+  branch: string;
+  on_clone?: SystemCommand;
+  on_pull?: SystemCommand;
+}
+
+export interface RepoInfo {
+  last_pulled_at?: number;
+  built_hash?: string;
+  latest_hash?: string;
+}
+
+export interface RepoActionState {
+  cloning: boolean;
+  pulling: boolean;
+  building: boolean;
+  renaming: boolean;
+}
+
+export interface RepoListItemInfo {
+  state: string;
+  repo: string;
+  server_id: string;
+}
+
+export type Repo = Resource<RepoConfig, RepoInfo>;
+export type RepoListItem = ResourceListItem<RepoListItemInfo>;
+
+// ---------------------------------------------------------------------------
+// Procedure
+// ---------------------------------------------------------------------------
+
+export interface ProcedureStage {
+  name: string;
+  enabled: boolean;
+  executions?: unknown[];
+}
+
+export interface ProcedureConfig {
+  stages?: ProcedureStage[];
+  webhook_enabled: boolean;
+  schedule?: string;
+  schedule_enabled: boolean;
+}
+
+export interface ProcedureActionState {
+  running: boolean;
+}
+
+export interface ProcedureListItemInfo {
+  stages: number;
+  state: string;
+}
+
+export type Procedure = Resource<ProcedureConfig, undefined>;
+export type ProcedureListItem = ResourceListItem<ProcedureListItemInfo>;
+
+// ---------------------------------------------------------------------------
+// Action
+// ---------------------------------------------------------------------------
+
+export interface ActionConfig {
+  webhook_enabled: boolean;
+  schedule?: string;
+  schedule_enabled: boolean;
+  run_at_startup: boolean;
+}
+
+export interface ActionActionState {
+  running: number;
+}
+
+export interface ActionListItemInfo {
+  state: string;
+  last_run_at?: number;
+}
+
+export type Action = Resource<ActionConfig, undefined>;
+export type ActionListItem = ResourceListItem<ActionListItemInfo>;
+
+// ---------------------------------------------------------------------------
+// Builder
+// ---------------------------------------------------------------------------
+
+export interface BuilderConfig {
+  type: string;
+  params: Record<string, string>;
+}
+
+export interface BuilderListItemInfo {
+  builder_type: string;
+  instance_type?: string;
+}
+
+export type Builder = Resource<BuilderConfig, undefined>;
+export type BuilderListItem = ResourceListItem<BuilderListItemInfo>;
+
+// ---------------------------------------------------------------------------
+// Alerter
+// ---------------------------------------------------------------------------
+
+export interface AlerterEndpoint {
+  type: string;
+}
+
+export interface AlerterConfig {
+  enabled?: boolean;
+  endpoint?: AlerterEndpoint;
+}
+
+export interface AlerterListItemInfo {
+  enabled: boolean;
+  endpoint_type: string;
+}
+
+export type Alerter = Resource<AlerterConfig, undefined>;
+export type AlerterListItem = ResourceListItem<AlerterListItemInfo>;
+
+// ---------------------------------------------------------------------------
+// ResourceSync
+// ---------------------------------------------------------------------------
+
+export interface ResourceSyncConfig {
+  git_provider: string;
+  repo?: string;
+  branch: string;
+  resource_path?: string[];
+}
+
+export interface ResourceSyncInfo {
+  last_sync_ts?: number;
+  last_sync_hash?: string;
+  pending_error?: string;
+  resource_updates?: unknown[];
+}
+
+export interface ResourceSyncActionState {
+  syncing: boolean;
+}
+
+export interface ResourceSyncListItemInfo {
+  state: string;
+  repo: string;
+  managed: boolean;
+}
+
+export type ResourceSync = Resource<ResourceSyncConfig, ResourceSyncInfo>;
+export type ResourceSyncListItem = ResourceListItem<ResourceSyncListItemInfo>;
+
+// ---------------------------------------------------------------------------
+// Update / Log
+// ---------------------------------------------------------------------------
+
+export interface Log {
+  stage: string;
+  command: string;
+  stdout: string;
+  stderr: string;
+  success: boolean;
+  start_ts: number;
+  end_ts: number;
+}
+
+export interface Update {
+  _id?: MongoId;
+  operation: string;
+  start_ts: number;
+  success: boolean;
+  operator: string;
+  target: ResourceTarget;
+  logs: Log[];
+  end_ts?: number;
+  status: string;
+  version?: Version;
+  commit_hash?: string;
+}
+
+export interface UpdateListItem {
+  id: string;
+  operation: string;
+  start_ts: number;
+  success: boolean;
+  username: string;
+  operator: string;
+  target: ResourceTarget;
+  status: string;
+  version?: Version;
+}


### PR DESCRIPTION
## Summary

Replaces the GPL-3.0 licensed `komodo_client` npm package with a native `fetch`-based HTTP client and cherry-picked type definitions, making the project fully MIT-licensed.

### Changes

**New file: `src/types/komodo.ts`** (~370 lines)
- Cherry-picked structural type definitions for all resource types consumed by the MCP server (Server, Stack, Deployment, Build, Repo, Procedure, Action, Builder, Alerter, ResourceSync, Update, Log)
- Includes `SearchCombinator` enum (only value-type import from the old SDK)
- Generic `Resource<Config, Info>` and `ResourceListItem<Info>` base types

**Rewritten: `src/core/client.ts`**
- `KomodoClient` class using native `fetch` with `AbortSignal.timeout(30_000)`
- Uniform `POST /{category}/{operation}` pattern with JSON body
- Auth via `x-api-key` + `x-api-secret` headers
- Throws `KomodoError` on non-200 responses
- `createClient()` and `validateConnection()` factory functions preserved for backward compatibility

**Modified: `src/core/errors.ts`**
- Added `KomodoError` class (consistent with `AdGuardError`/`PveError` in sibling packages)

**Modified: `src/core/formatters.ts`**
- Replaced `import { Types } from "komodo_client"` with individual type imports from `../types/komodo.js`
- Removed all `Types.` prefixes

**Modified: All 13 tool files in `src/tools/`**
- Replaced `import type { createClient }` → `import type { KomodoClient }` from `../core/client.js`
- Removed `type KomodoClient = ReturnType<typeof createClient>` alias
- Replaced `Types.SearchCombinator` → `SearchCombinator` (in stacks, deployments, containers)

**Modified: `src/tests/handlers.test.ts`, `src/tests/helpers.ts`**
- Updated imports to use `KomodoClient` type directly

**Modified: `package.json`, `package-lock.json`**
- Removed `komodo_client: ^1.19.5` from dependencies