### PR TITLE
feat: add tool titles with MCP_EXCLUDE_TOOL_TITLES opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Set `KOMODO_ACCESS_TIER` to `read-only`, `read-execute`, or `full` (default: `fu
 | `MCP_TRANSPORT` | No | `stdio` | Transport mode: `stdio` (default) or `http` |
 | `MCP_PORT` | No | `3000` | HTTP server port (only used when `MCP_TRANSPORT=http`) |
 | `MCP_HOST` | No | `0.0.0.0` | HTTP server bind address (only used when `MCP_TRANSPORT=http`) |
+| `MCP_EXCLUDE_TOOL_TITLES` | No | `false` | Set `true` to omit tool titles from registration (saves tokens) |
 
 Generate API keys in the Komodo UI under **Settings > API Keys**.
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -11,6 +11,7 @@ export interface AppConfig {
   apiSecret: string;
   accessTier: AccessTier;
   categories: string[] | null;
+  excludeToolTitles: boolean;
   debug: boolean;
   transport: 'stdio' | 'http';
   httpPort: number;
@@ -66,6 +67,8 @@ export function loadConfig(): AppConfig {
     );
   }
 
+  const excludeToolTitles = process.env.MCP_EXCLUDE_TOOL_TITLES === "true";
+
   const transport =
     process.env.MCP_TRANSPORT === 'http' ? ('http' as const) : ('stdio' as const);
   const rawPort = process.env.MCP_PORT ?? '3000';
@@ -83,6 +86,7 @@ export function loadConfig(): AppConfig {
     apiSecret: apiSecret!,
     accessTier: parseAccessTier(),
     categories: parseCategories(process.env.KOMODO_CATEGORIES),
+    excludeToolTitles,
     debug: Boolean(process.env.DEBUG),
     transport,
     httpPort,

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -22,6 +22,7 @@ const TIER_LEVELS: Record<AccessTier, number> = {
 
 export interface ToolRegistrationOptions {
   name: string;
+  title: string;
   description: string;
   accessTier: AccessTier;
   category: string;
@@ -67,10 +68,12 @@ export function registerTool(
   };
 
   const toolConfig: {
+    title?: string;
     description: string;
     inputSchema?: ZodRawShape;
     annotations: ToolAnnotations;
   } = {
+    ...(!config.excludeToolTitles && { title: options.title }),
     description: options.description,
     annotations,
   };

--- a/src/tests/helpers.ts
+++ b/src/tests/helpers.ts
@@ -12,6 +12,7 @@ export function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     apiSecret: "test-api-secret",
     accessTier: "full",
     categories: null,
+    excludeToolTitles: false,
     debug: false,
     transport: "stdio",
     httpPort: 3000,

--- a/src/tests/registration.test.ts
+++ b/src/tests/registration.test.ts
@@ -64,6 +64,30 @@ describe("tool registration", () => {
     await filteredConn.cleanup();
   });
 
+  describe("tool titles", () => {
+    it("includes titles by default", async () => {
+      const server = createServer();
+      registerAllTools(server, makeMockClient(), makeConfig());
+      const { client, cleanup } = await connectTestClient(server);
+      const { tools } = await client.listTools();
+      for (const tool of tools) {
+        expect(tool.title, `${tool.name} missing title`).toBeDefined();
+      }
+      await cleanup();
+    });
+
+    it("excludes titles when excludeToolTitles is true", async () => {
+      const server = createServer();
+      registerAllTools(server, makeMockClient(), makeConfig({ excludeToolTitles: true }));
+      const { client, cleanup } = await connectTestClient(server);
+      const { tools } = await client.listTools();
+      for (const tool of tools) {
+        expect(tool.title, `${tool.name} should not have title`).toBeUndefined();
+      }
+      await cleanup();
+    });
+  });
+
   describe("annotations", () => {
     it("komodo_list_servers: readOnly, not destructive, idempotent", async () => {
       const server = createServer();

--- a/src/tools/actions.ts
+++ b/src/tools/actions.ts
@@ -23,6 +23,7 @@ export function registerActionTools(server: McpServer, client: KomodoClient, con
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_list_actions",
+    title: "List Actions",
     description:
       "List all Komodo Actions. An Action is a custom TypeScript/Deno " +
       "script that runs on the Komodo Core server. Returns name and " +
@@ -57,6 +58,7 @@ export function registerActionTools(server: McpServer, client: KomodoClient, con
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_get_action",
+    title: "Get Action",
     description:
       "Get detailed information about a specific Komodo Action by name " +
       "or ID. An Action is a custom TypeScript/Deno script that runs on " +
@@ -98,6 +100,7 @@ export function registerActionTools(server: McpServer, client: KomodoClient, con
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_run_action",
+    title: "Run Action",
     description:
       "\u26a0\ufe0f RUN a Komodo Action. This executes a custom TypeScript/Deno " +
       "script on the Komodo Core server. Actions can perform arbitrary " +

--- a/src/tools/alerters.ts
+++ b/src/tools/alerters.ts
@@ -20,6 +20,7 @@ export function registerAlerterTools(server: McpServer, client: KomodoClient, co
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_list_alerters",
+    title: "List Alerters",
     description:
       "List all Komodo Alerters. An Alerter is a notification endpoint " +
       "(Slack, Discord, or custom webhook) for Komodo alerts and status " +
@@ -56,6 +57,7 @@ export function registerAlerterTools(server: McpServer, client: KomodoClient, co
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_get_alerter",
+    title: "Get Alerter",
     description:
       "Get detailed information about a specific Komodo Alerter by name " +
       "or ID. An Alerter is a notification endpoint for Komodo alerts. " +

--- a/src/tools/builders.ts
+++ b/src/tools/builders.ts
@@ -20,6 +20,7 @@ export function registerBuilderTools(server: McpServer, client: KomodoClient, co
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_list_builders",
+    title: "List Builders",
     description:
       "List all Komodo Builders. A Builder is a build server (or AWS " +
       "instance) used to compile Docker images for Komodo Builds. " +
@@ -56,6 +57,7 @@ export function registerBuilderTools(server: McpServer, client: KomodoClient, co
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_get_builder",
+    title: "Get Builder",
     description:
       "Get detailed information about a specific Komodo Builder by name " +
       "or ID. A Builder is a build server used to compile Docker images. " +

--- a/src/tools/builds.ts
+++ b/src/tools/builds.ts
@@ -24,6 +24,7 @@ export function registerBuildTools(server: McpServer, client: KomodoClient, conf
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_list_builds",
+    title: "List Builds",
     description:
       "List all Komodo Builds. A Build is a Docker image build " +
       "configuration that compiles source code into container images " +
@@ -59,6 +60,7 @@ export function registerBuildTools(server: McpServer, client: KomodoClient, conf
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_get_build",
+    title: "Get Build",
     description:
       "Get detailed information about a specific Komodo Build by name " +
       "or ID. A Build is a Docker image build configuration. Returns " +
@@ -99,6 +101,7 @@ export function registerBuildTools(server: McpServer, client: KomodoClient, conf
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_run_build",
+    title: "Run Build",
     description:
       "\u26a0\ufe0f RUN a Komodo Build to create a Docker image. This clones the " +
       "repo (if needed), runs docker build, and pushes the resulting image " +
@@ -138,6 +141,7 @@ export function registerBuildTools(server: McpServer, client: KomodoClient, conf
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_cancel_build",
+    title: "Cancel Build",
     description:
       "Cancel a running Komodo Build. Stops the build process if it is " +
       "currently in progress. Has no effect if the build is not running. " +

--- a/src/tools/containers.ts
+++ b/src/tools/containers.ts
@@ -21,6 +21,7 @@ export function registerContainerTools(server: McpServer, client: KomodoClient, 
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_get_container_log",
+    title: "Get Container Log",
     description:
       "Get logs from a Docker container running on a Komodo Server. " +
       "Requires both the server name and the container name. " +

--- a/src/tools/deployments.ts
+++ b/src/tools/deployments.ts
@@ -28,6 +28,7 @@ export function registerDeploymentTools(server: McpServer, client: KomodoClient,
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_list_deployments",
+    title: "List Deployments",
     description:
       "List all Komodo Deployments. A Deployment is a single Docker " +
       "container managed by Komodo, deployed to a specific server. " +
@@ -64,6 +65,7 @@ export function registerDeploymentTools(server: McpServer, client: KomodoClient,
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_get_deployment",
+    title: "Get Deployment",
     description:
       "Get detailed information about a specific Komodo Deployment by " +
       "name or ID. A Deployment is a single Docker container managed by " +
@@ -108,6 +110,7 @@ export function registerDeploymentTools(server: McpServer, client: KomodoClient,
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_get_deployment_log",
+    title: "Get Deployment Log",
     description:
       "Get logs from a Komodo Deployment's Docker container. Optionally " +
       "search for specific terms in the log output. A Deployment is a " +
@@ -178,6 +181,7 @@ export function registerDeploymentTools(server: McpServer, client: KomodoClient,
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_inspect_deployment_container",
+    title: "Inspect Deployment Container",
     description:
       "Inspect the Docker container associated with a Deployment. " +
       "Returns the full container state including configuration, mounts, " +
@@ -210,6 +214,7 @@ export function registerDeploymentTools(server: McpServer, client: KomodoClient,
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_get_deployments_summary",
+    title: "Get Deployments Summary",
     description:
       "Get a summary of all Komodo Deployments. Returns aggregate counts " +
       "by state: total, running, stopped, not deployed, unhealthy, " +
@@ -243,6 +248,7 @@ export function registerDeploymentTools(server: McpServer, client: KomodoClient,
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_deploy_deployment",
+    title: "Deploy",
     description:
       "\u26a0\ufe0f DEPLOY a Komodo Deployment. This stops the current container " +
       "and starts a new one with the latest image and configuration. The " +
@@ -287,6 +293,7 @@ export function registerDeploymentTools(server: McpServer, client: KomodoClient,
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_pull_deployment",
+    title: "Pull Deployment Image",
     description:
       "\u26a0\ufe0f PULL the image for a Komodo Deployment (docker pull). " +
       "Downloads the latest image without redeploying the container. " +
@@ -333,6 +340,7 @@ export function registerDeploymentTools(server: McpServer, client: KomodoClient,
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_deployment_lifecycle",
+    title: "Manage Deployment Lifecycle",
     description:
       "\u26a0\ufe0f LIFECYCLE: Control a Komodo Deployment's container lifecycle. " +
       "A Deployment is a single Docker container managed by Komodo. " +
@@ -392,6 +400,7 @@ export function registerDeploymentTools(server: McpServer, client: KomodoClient,
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_destroy_deployment",
+    title: "Destroy Deployment",
     description:
       "\ud83d\udd34 DESTROY a Komodo Deployment permanently. This stops the " +
       "container and removes the deployment configuration from Komodo. " +

--- a/src/tools/procedures.ts
+++ b/src/tools/procedures.ts
@@ -24,6 +24,7 @@ export function registerProcedureTools(server: McpServer, client: KomodoClient, 
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_list_procedures",
+    title: "List Procedures",
     description:
       "List all Komodo Procedures. A Procedure is an orchestrated " +
       "sequence of parallel stages that run other Komodo operations " +
@@ -64,6 +65,7 @@ export function registerProcedureTools(server: McpServer, client: KomodoClient, 
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_get_procedure",
+    title: "Get Procedure",
     description:
       "Get detailed information about a specific Komodo Procedure by " +
       "name or ID. A Procedure is an orchestrated sequence of stages. " +
@@ -107,6 +109,7 @@ export function registerProcedureTools(server: McpServer, client: KomodoClient, 
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_run_procedure",
+    title: "Run Procedure",
     description:
       "\u26a0\ufe0f RUN a Komodo Procedure. This executes all stages in sequence, " +
       "where each stage can run multiple operations in parallel. A " +

--- a/src/tools/repos.ts
+++ b/src/tools/repos.ts
@@ -24,6 +24,7 @@ export function registerRepoTools(server: McpServer, client: KomodoClient, confi
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_list_repos",
+    title: "List Repos",
     description:
       "List all Komodo Repos. A Repo is a Git repository cloned to a " +
       "server, optionally built using a Builder. Returns name, repo URL, " +
@@ -58,6 +59,7 @@ export function registerRepoTools(server: McpServer, client: KomodoClient, confi
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_get_repo",
+    title: "Get Repo",
     description:
       "Get detailed information about a specific Komodo Repo by name " +
       "or ID. A Repo is a Git repository cloned to a server. Returns " +
@@ -99,6 +101,7 @@ export function registerRepoTools(server: McpServer, client: KomodoClient, confi
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_repo_clone_pull",
+    title: "Clone or Pull Repo",
     description:
       "\u26a0\ufe0f CLONE or PULL a Komodo Repo on its target server. 'clone' " +
       "performs initial git clone (or pulls if already cloned). 'pull' " +

--- a/src/tools/resource-syncs.ts
+++ b/src/tools/resource-syncs.ts
@@ -24,6 +24,7 @@ export function registerResourceSyncTools(server: McpServer, client: KomodoClien
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_list_resource_syncs",
+    title: "List Resource Syncs",
     description:
       "List all Komodo Resource Syncs. A Resource Sync is a GitOps sync " +
       "that manages Komodo resources from TOML configuration files in a " +
@@ -63,6 +64,7 @@ export function registerResourceSyncTools(server: McpServer, client: KomodoClien
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_get_resource_sync",
+    title: "Get Resource Sync",
     description:
       "Get detailed information about a specific Komodo Resource Sync " +
       "by name or ID. A Resource Sync manages Komodo resources from TOML " +
@@ -109,6 +111,7 @@ export function registerResourceSyncTools(server: McpServer, client: KomodoClien
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_trigger_sync",
+    title: "Trigger Resource Sync",
     description:
       "\u26a0\ufe0f TRIGGER a Komodo Resource Sync. This pulls the latest TOML " +
       "configuration from the Git repo and applies changes to managed " +

--- a/src/tools/servers.ts
+++ b/src/tools/servers.ts
@@ -26,6 +26,7 @@ export function registerServerTools(server: McpServer, client: KomodoClient, con
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_list_servers",
+    title: "List Servers",
     description:
       "List all Komodo Servers. A Server is a remote machine managed " +
       "by Komodo's Periphery agent. Returns name, status, and region " +
@@ -60,6 +61,7 @@ export function registerServerTools(server: McpServer, client: KomodoClient, con
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_get_server",
+    title: "Get Server",
     description:
       "Get detailed information about a specific Komodo Server by name " +
       "or ID. A Server is a remote machine managed by Komodo's Periphery " +
@@ -103,6 +105,7 @@ export function registerServerTools(server: McpServer, client: KomodoClient, con
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_get_server_stats",
+    title: "Get Server Stats",
     description:
       "Get current resource usage statistics for a Komodo Server. " +
       "A Server is a remote machine managed by Komodo's Periphery agent. " +
@@ -143,6 +146,7 @@ export function registerServerTools(server: McpServer, client: KomodoClient, con
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_get_server_info",
+    title: "Get Server Info",
     description:
       "Get system information and running processes for a Komodo Server. " +
       "A Server is a remote machine managed by Komodo's Periphery agent. " +
@@ -183,6 +187,7 @@ export function registerServerTools(server: McpServer, client: KomodoClient, con
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_inspect_docker_container",
+    title: "Inspect Docker Container",
     description:
       "Inspect a Docker container on a Komodo Server. Returns the full " +
       "container state including configuration, mounts, network settings, " +
@@ -217,6 +222,7 @@ export function registerServerTools(server: McpServer, client: KomodoClient, con
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_inspect_docker_image",
+    title: "Inspect Docker Image",
     description:
       "Inspect a Docker image on a Komodo Server. Returns the full image " +
       "metadata including layers, configuration, labels, and creation info " +
@@ -251,6 +257,7 @@ export function registerServerTools(server: McpServer, client: KomodoClient, con
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_inspect_docker_network",
+    title: "Inspect Docker Network",
     description:
       "Inspect a Docker network on a Komodo Server. Returns the full " +
       "network configuration including driver, IPAM settings, connected " +
@@ -285,6 +292,7 @@ export function registerServerTools(server: McpServer, client: KomodoClient, con
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_inspect_docker_volume",
+    title: "Inspect Docker Volume",
     description:
       "Inspect a Docker volume on a Komodo Server. Returns the full " +
       "volume metadata including driver, mount point, labels, and options " +
@@ -319,6 +327,7 @@ export function registerServerTools(server: McpServer, client: KomodoClient, con
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_prune_docker",
+    title: "Prune Docker Resources",
     description:
       "\u26a0\ufe0f PRUNE unused Docker resources on a specific Komodo Server. " +
       "Removes stopped containers, dangling images, unused volumes, or " +
@@ -393,6 +402,7 @@ export function registerServerTools(server: McpServer, client: KomodoClient, con
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_delete_docker_resource",
+    title: "Delete Docker Resource",
     description:
       "\u26a0\ufe0f DELETE a specific Docker resource (image, volume, or network) " +
       "on a Komodo Server. Unlike prune which removes all unused resources, " +

--- a/src/tools/stacks.ts
+++ b/src/tools/stacks.ts
@@ -29,6 +29,7 @@ export function registerStackTools(server: McpServer, client: KomodoClient, conf
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_list_stacks",
+    title: "List Stacks",
     description:
       "List all Komodo Stacks. A Stack is a multi-container deployment " +
       "defined by a Docker Compose file, deployed to a specific server. " +
@@ -63,6 +64,7 @@ export function registerStackTools(server: McpServer, client: KomodoClient, conf
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_get_stack",
+    title: "Get Stack",
     description:
       "Get detailed information about a specific Komodo Stack by name " +
       "or ID. A Stack is a multi-container deployment defined by a Docker " +
@@ -104,6 +106,7 @@ export function registerStackTools(server: McpServer, client: KomodoClient, conf
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_get_stack_log",
+    title: "Get Stack Log",
     description:
       "Get logs from a Komodo Stack's Docker Compose services. Optionally " +
       "search for specific terms in the log output. A Stack is a " +
@@ -183,6 +186,7 @@ export function registerStackTools(server: McpServer, client: KomodoClient, conf
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_inspect_stack_container",
+    title: "Inspect Stack Container",
     description:
       "Inspect a Docker container for a specific service within a Stack. " +
       "Returns the full container state including configuration, mounts, " +
@@ -217,6 +221,7 @@ export function registerStackTools(server: McpServer, client: KomodoClient, conf
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_list_stack_services",
+    title: "List Stack Services",
     description:
       "List all services in a Komodo Stack. Returns the service name, " +
       "Docker image, container state, and whether an image update is " +
@@ -257,6 +262,7 @@ export function registerStackTools(server: McpServer, client: KomodoClient, conf
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_get_stacks_summary",
+    title: "Get Stacks Summary",
     description:
       "Get a summary of all Komodo Stacks. Returns aggregate counts " +
       "by state: total, running, stopped, down, unhealthy, and unknown.",
@@ -289,6 +295,7 @@ export function registerStackTools(server: McpServer, client: KomodoClient, conf
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_deploy_stack",
+    title: "Deploy Stack",
     description:
       "\u26a0\ufe0f DEPLOY a Komodo Stack. This redeploys all services in the stack, " +
       "taking down containers and bringing them back up with the latest " +
@@ -350,6 +357,7 @@ export function registerStackTools(server: McpServer, client: KomodoClient, conf
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_pull_stack",
+    title: "Pull Stack Images",
     description:
       "\u26a0\ufe0f PULL images for a Komodo Stack (docker compose pull). " +
       "Downloads the latest images without redeploying. Use this to " +
@@ -405,6 +413,7 @@ export function registerStackTools(server: McpServer, client: KomodoClient, conf
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_stack_lifecycle",
+    title: "Manage Stack Lifecycle",
     description:
       "\u26a0\ufe0f LIFECYCLE: Control a Komodo Stack's container lifecycle. " +
       "Start brings up all containers, stop brings them down gracefully, " +
@@ -458,6 +467,7 @@ export function registerStackTools(server: McpServer, client: KomodoClient, conf
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_destroy_stack",
+    title: "Destroy Stack",
     description:
       "\ud83d\udd34 DESTROY a Komodo Stack permanently. This stops all containers " +
       "and removes the stack configuration from Komodo. THIS CANNOT BE " +

--- a/src/tools/updates.ts
+++ b/src/tools/updates.ts
@@ -23,6 +23,7 @@ export function registerUpdateTools(server: McpServer, client: KomodoClient, con
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_list_updates",
+    title: "List Updates",
     description:
       "List Komodo operation history (updates). Every execute operation " +
       "(deploy, start, stop, build, pull, etc.) creates an Update record. " +
@@ -105,6 +106,7 @@ export function registerUpdateTools(server: McpServer, client: KomodoClient, con
   // -------------------------------------------------------------------------
   registerTool(server, config, {
     name: "komodo_get_update",
+    title: "Get Update",
     description:
       "Get detailed information about a specific Komodo Update (operation " +
       "record) by ID. Returns the full operation details including status, " +

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -282,6 +282,7 @@ async function handleDelete(
 export function registerWriteTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
   registerTool(server, config, {
     name: "komodo_write_resource",
+    title: "Write Resource",
     description:
       "Create, update, or delete any Komodo resource. Supports all 10 resource " +
       "types: Stack, Deployment, Build, Repo, Procedure, Action, Alerter, " +


### PR DESCRIPTION
## Summary

Add human-readable `title` fields to all tool registrations and introduce `MCP_EXCLUDE_TOOL_TITLES` env var to optionally omit them.

- **Tool titles**: Every `registerTool()` call now includes a `title` — a human-readable display name (e.g. "List Servers", "Deploy Stack") shown in client UIs per MCP spec 2025-11-25. Titles use Title Case with acronyms kept uppercase.
- **`MCP_EXCLUDE_TOOL_TITLES` env var**: When set to `true`, titles are omitted from tool registrations to reduce token usage. Default: `false` (titles included).
- **Tests**: 2 new registration tests verify titles are present by default and absent when `excludeToolTitles: true`.

### Files changed

- `src/core/config.ts` — added `excludeToolTitles: boolean` to `AppConfig`, parsed from `MCP_EXCLUDE_TOOL_TITLES` env var
- `src/core/tools.ts` — conditionally spread `title` into tool config based on `config.excludeToolTitles`
- `src/tools/*.ts` — added `title` field to every `registerTool()` call
- `src/tests/helpers.ts` — added `excludeToolTitles: false` to `makeConfig()` defaults
- `src/tests/registration.test.ts` — 2 new test cases for title inclusion/exclusion
- `README.md` — added `MCP_EXCLUDE_TOOL_TITLES` to environment variables table