### PR TITLE
feat: add tool blacklist/whitelist support

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ Set `KOMODO_ACCESS_TIER` to `read-only`, `read-execute`, or `full` (default: `fu
 | `KOMODO_API_SECRET` | Yes | -- | API secret for authentication |
 | `KOMODO_ACCESS_TIER` | No | `full` | Access tier: `read-only`, `read-execute`, or `full` |
 | `KOMODO_CATEGORIES` | No | *(all)* | Comma-separated category allowlist (e.g., `servers,stacks,builds`) |
+| `KOMODO_TOOL_BLACKLIST` | No | *(none)* | Comma-separated list of tool names to exclude (e.g., `komodo_destroy_stack`) |
+| `KOMODO_TOOL_WHITELIST` | No | *(none)* | Comma-separated list of tool names to force-include, bypassing access tier and category filters |
 | `DEBUG` | No | -- | Set to any value to enable debug logging to stderr |
 | `MCP_TRANSPORT` | No | `stdio` | Transport mode: `stdio` (default) or `http` |
 | `MCP_PORT` | No | `3000` | HTTP server port (only used when `MCP_TRANSPORT=http`) |

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -11,6 +11,8 @@ export interface AppConfig {
   apiSecret: string;
   accessTier: AccessTier;
   categories: string[] | null;
+  toolBlacklist: string[] | null;
+  toolWhitelist: string[] | null;
   excludeToolTitles: boolean;
   debug: boolean;
   transport: 'stdio' | 'http';
@@ -33,6 +35,16 @@ function parseAccessTier(): AccessTier {
 }
 
 function parseCategories(value: string | undefined): string[] | null {
+  if (value === undefined || value === '') {
+    return null;
+  }
+  return value
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function parseToolList(value: string | undefined): string[] | null {
   if (value === undefined || value === '') {
     return null;
   }
@@ -86,6 +98,8 @@ export function loadConfig(): AppConfig {
     apiSecret: apiSecret!,
     accessTier: parseAccessTier(),
     categories: parseCategories(process.env.KOMODO_CATEGORIES),
+    toolBlacklist: parseToolList(process.env.KOMODO_TOOL_BLACKLIST),
+    toolWhitelist: parseToolList(process.env.KOMODO_TOOL_WHITELIST),
     excludeToolTitles,
     debug: Boolean(process.env.DEBUG),
     transport,

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -1,6 +1,6 @@
 /**
  * Tool registration helper. Wraps MCP server.registerTool() with
- * access tier checking.
+ * access tier checking, category filtering, and blacklist/whitelist support.
  *
  * Komodo uses a 3-tier model: "read-only" < "read-execute" < "full".
  * Each tool declares its minimum tier. The wrapper skips tools whose
@@ -34,31 +34,63 @@ export interface ToolRegistrationOptions {
   }>;
 }
 
+/** Tracks all tool names seen during registration for post-registration validation. */
+const seenToolNames = new Set<string>();
+
 /**
- * Register a tool with the MCP server, respecting access tier.
+ * Register a tool with the MCP server, respecting blacklist/whitelist,
+ * access tier, and category filters.
  *
- * Returns true if the tool was registered, false if filtered out.
+ * Filter precedence:
+ * 1. Blacklist always wins (even over whitelist — logs warning if both)
+ * 2. Whitelist bypasses access tier and category filters
+ * 3. Access tier gate
+ * 4. Category gate
  *
  * Unlike AdGuard/Authentik, Komodo handlers return the full MCP response
  * format (including error handling), so the wrapper does not add error wrapping.
+ *
+ * Returns true if the tool was registered, false if filtered out.
  */
 export function registerTool(
   server: McpServer,
   config: AppConfig,
   options: ToolRegistrationOptions,
 ): boolean {
-  if (TIER_LEVELS[config.accessTier] < TIER_LEVELS[options.accessTier]) {
-    logger.debug(
-      `Skipping tool "${options.name}" (requires ${options.accessTier}, running in ${config.accessTier} mode)`,
-    );
+  seenToolNames.add(options.name);
+
+  const isBlacklisted =
+    config.toolBlacklist !== null && config.toolBlacklist.includes(options.name);
+  const isWhitelisted =
+    config.toolWhitelist !== null && config.toolWhitelist.includes(options.name);
+
+  // Blacklist always wins
+  if (isBlacklisted) {
+    if (isWhitelisted) {
+      logger.warn(
+        `Tool "${options.name}" is both blacklisted and whitelisted — blacklist takes precedence, skipping`,
+      );
+    } else {
+      logger.debug(`Skipping tool "${options.name}" (blacklisted)`);
+    }
     return false;
   }
 
-  if (config.categories !== null && !config.categories.includes(options.category)) {
-    logger.debug(
-      `Skipping tool "${options.name}" (category "${options.category}" not in allowed categories)`,
-    );
-    return false;
+  // Whitelist bypasses tier and category filters
+  if (!isWhitelisted) {
+    if (TIER_LEVELS[config.accessTier] < TIER_LEVELS[options.accessTier]) {
+      logger.debug(
+        `Skipping tool "${options.name}" (requires ${options.accessTier}, running in ${config.accessTier} mode)`,
+      );
+      return false;
+    }
+
+    if (config.categories !== null && !config.categories.includes(options.category)) {
+      logger.debug(
+        `Skipping tool "${options.name}" (category "${options.category}" not in allowed categories)`,
+      );
+      return false;
+    }
   }
 
   const annotations: ToolAnnotations = {
@@ -87,4 +119,21 @@ export function registerTool(
   });
 
   return true;
+}
+
+/**
+ * Validate that all tool names in blacklist/whitelist actually exist.
+ * Call after registerAllTools() to warn about typos or stale entries.
+ */
+export function validateToolLists(config: AppConfig): void {
+  for (const name of config.toolBlacklist ?? []) {
+    if (!seenToolNames.has(name)) {
+      logger.warn(`Blacklisted tool "${name}" does not match any known tool`);
+    }
+  }
+  for (const name of config.toolWhitelist ?? []) {
+    if (!seenToolNames.has(name)) {
+      logger.warn(`Whitelisted tool "${name}" does not match any known tool`);
+    }
+  }
 }

--- a/src/tests/helpers.ts
+++ b/src/tests/helpers.ts
@@ -12,6 +12,8 @@ export function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     apiSecret: "test-api-secret",
     accessTier: "full",
     categories: null,
+    toolBlacklist: null,
+    toolWhitelist: null,
     excludeToolTitles: false,
     debug: false,
     transport: "stdio",

--- a/src/tests/registration.test.ts
+++ b/src/tests/registration.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { createServer } from "../core/server.js";
 import { registerAllTools } from "../tools/index.js";
+import { logger } from "../core/logger.js";
 import { makeConfig, makeMockClient, connectTestClient } from "./helpers.js";
 
 describe("tool registration", () => {
@@ -85,6 +86,98 @@ describe("tool registration", () => {
         expect(tool.title, `${tool.name} should not have title`).toBeUndefined();
       }
       await cleanup();
+    });
+  });
+
+  describe("blacklist/whitelist", () => {
+    it("blacklist excludes specific tools", async () => {
+      const server = createServer();
+      registerAllTools(server, makeMockClient(), makeConfig({ toolBlacklist: ["komodo_list_servers"] }));
+      const { client, cleanup } = await connectTestClient(server);
+      const { tools } = await client.listTools();
+      const names = tools.map((t) => t.name);
+      expect(names).not.toContain("komodo_list_servers");
+      await cleanup();
+    });
+
+    it("blacklist does not affect non-blacklisted tools", async () => {
+      const server = createServer();
+      registerAllTools(server, makeMockClient(), makeConfig({ toolBlacklist: ["komodo_list_servers"] }));
+      const { client, cleanup } = await connectTestClient(server);
+      const { tools } = await client.listTools();
+      const names = tools.map((t) => t.name);
+      expect(names).toContain("komodo_write_resource");
+      await cleanup();
+    });
+
+    it("whitelist includes tool excluded by tier filter", async () => {
+      const server = createServer();
+      registerAllTools(server, makeMockClient(), makeConfig({
+        accessTier: "read-only",
+        toolWhitelist: ["komodo_write_resource"],
+      }));
+      const { client, cleanup } = await connectTestClient(server);
+      const { tools } = await client.listTools();
+      const names = tools.map((t) => t.name);
+      expect(names).toContain("komodo_write_resource");
+      await cleanup();
+    });
+
+    it("whitelist includes tool excluded by category filter", async () => {
+      const server = createServer();
+      registerAllTools(server, makeMockClient(), makeConfig({
+        categories: ["servers"],
+        toolWhitelist: ["komodo_list_stacks"],
+      }));
+      const { client, cleanup } = await connectTestClient(server);
+      const { tools } = await client.listTools();
+      const names = tools.map((t) => t.name);
+      expect(names).toContain("komodo_list_stacks");
+      await cleanup();
+    });
+
+    it("blacklist takes precedence over whitelist", async () => {
+      const server = createServer();
+      registerAllTools(server, makeMockClient(), makeConfig({
+        toolBlacklist: ["komodo_list_servers"],
+        toolWhitelist: ["komodo_list_servers"],
+      }));
+      const { client, cleanup } = await connectTestClient(server);
+      const { tools } = await client.listTools();
+      const names = tools.map((t) => t.name);
+      expect(names).not.toContain("komodo_list_servers");
+      await cleanup();
+    });
+
+    it("blacklist + whitelist conflict logs warning", async () => {
+      const spy = vi.spyOn(logger, "warn");
+      const server = createServer();
+      registerAllTools(server, makeMockClient(), makeConfig({
+        toolBlacklist: ["komodo_list_servers"],
+        toolWhitelist: ["komodo_list_servers"],
+      }));
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining("blacklist takes precedence"));
+      spy.mockRestore();
+    });
+
+    it("validates unknown blacklisted tool name", async () => {
+      const spy = vi.spyOn(logger, "warn");
+      const server = createServer();
+      registerAllTools(server, makeMockClient(), makeConfig({
+        toolBlacklist: ["nonexistent_tool_xyz"],
+      }));
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining("does not match"));
+      spy.mockRestore();
+    });
+
+    it("validates unknown whitelisted tool name", async () => {
+      const spy = vi.spyOn(logger, "warn");
+      const server = createServer();
+      registerAllTools(server, makeMockClient(), makeConfig({
+        toolWhitelist: ["nonexistent_tool_abc"],
+      }));
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining("does not match"));
+      spy.mockRestore();
     });
   });
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -8,6 +8,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
+import { validateToolLists } from "../core/tools.js";
 import { registerServerTools } from "./servers.js";
 import { registerStackTools } from "./stacks.js";
 import { registerDeploymentTools } from "./deployments.js";
@@ -40,4 +41,6 @@ export function registerAllTools(
   registerResourceSyncTools(server, client, config);
   registerUpdateTools(server, client, config);
   registerWriteTools(server, client, config);
+
+  validateToolLists(config);
 }


### PR DESCRIPTION
## Summary

Adds per-tool blacklist/whitelist environment variables for fine-grained tool control, complementing the existing access tier and category filters.

- **`KOMODO_TOOL_BLACKLIST`** — comma-separated tool names to exclude (always wins, even over whitelist)
- **`KOMODO_TOOL_WHITELIST`** — comma-separated tool names to force-include (bypasses tier and category filters)

### Changes

- **`src/core/config.ts`** — Added `parseToolList()` helper and parsing of `KOMODO_TOOL_BLACKLIST` / `KOMODO_TOOL_WHITELIST` env vars into `AppConfig`. Also added `toolBlacklist` and `toolWhitelist` fields to the inline `AppConfig` interface
- **`src/core/tools.ts`** — Updated `registerTool()` with 4-step filter precedence: blacklist → whitelist → tier → category. Added `seenToolNames` tracking and `validateToolLists()` for post-registration name validation (warns about typos/stale entries)
- **`src/tools/index.ts`** — Calls `validateToolLists(config)` after all tools are registered
- **`src/tests/helpers.ts`** — Added `toolBlacklist: null` and `toolWhitelist: null` defaults to `makeConfig()`
- **`src/tests/registration.test.ts`** — Added 7 tests covering: blacklist exclusion, whitelist tier bypass, whitelist category bypass, blacklist precedence over whitelist, conflict warning logging, and unknown tool name validation
- **`README.md`** — Documented the new environment variables in the configuration table