### PR TITLE
chore: add Biome linter and formatter with CI integration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   ci:
-    name: Build, Test & Typecheck
+    name: Lint, Test & Typecheck
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,6 +19,7 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      - run: npm run lint
       - run: npm test
       - run: npm run build
 

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true,
+    "defaultBranch": "main"
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 80,
+    "lineEnding": "lf"
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUnusedVariables": "error",
+        "noUnusedImports": "error"
+      },
+      "suspicious": {
+        "noExplicitAny": "off"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "trailingCommas": "all",
+      "semicolons": "always"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,176 @@
         "mcp-komodo": "dist/index.js"
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.4.6",
         "@types/node": "^22.0.0",
         "typescript": "~5.9.3",
         "vitest": "^3.0.0"
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.6.tgz",
+      "integrity": "sha512-QnHe81PMslpy3mnpL8DnO2M4S4ZnYPkjlGCLWBZT/3R9M6b5daArWMMtEfP52/n174RKnwRIf3oT8+wc9ihSfQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.6",
+        "@biomejs/cli-darwin-x64": "2.4.6",
+        "@biomejs/cli-linux-arm64": "2.4.6",
+        "@biomejs/cli-linux-arm64-musl": "2.4.6",
+        "@biomejs/cli-linux-x64": "2.4.6",
+        "@biomejs/cli-linux-x64-musl": "2.4.6",
+        "@biomejs/cli-win32-arm64": "2.4.6",
+        "@biomejs/cli-win32-x64": "2.4.6"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.6.tgz",
+      "integrity": "sha512-NW18GSyxr+8sJIqgoGwVp5Zqm4SALH4b4gftIA0n62PTuBs6G2tHlwNAOj0Vq0KKSs7Sf88VjjmHh0O36EnzrQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.6.tgz",
+      "integrity": "sha512-4uiE/9tuI7cnjtY9b07RgS7gGyYOAfIAGeVJWEfeCnAarOAS7qVmuRyX6d7JTKw28/mt+rUzMasYeZ+0R/U1Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.6.tgz",
+      "integrity": "sha512-kMLaI7OF5GN1Q8Doymjro1P8rVEoy7BKQALNz6fiR8IC1WKduoNyteBtJlHT7ASIL0Cx2jR6VUOBIbcB1B8pew==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.6.tgz",
+      "integrity": "sha512-F/JdB7eN22txiTqHM5KhIVt0jVkzZwVYrdTR1O3Y4auBOQcXxHK4dxULf4z43QyZI5tsnQJrRBHZy7wwtL+B3A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.6.tgz",
+      "integrity": "sha512-oHXmUFEoH8Lql1xfc3QkFLiC1hGR7qedv5eKNlC185or+o4/4HiaU7vYODAH3peRCfsuLr1g6v2fK9dFFOYdyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.6.tgz",
+      "integrity": "sha512-C9s98IPDu7DYarjlZNuzJKTjVHN03RUnmHV5htvqsx6vEUXCDSJ59DNwjKVD5XYoSS4N+BYhq3RTBAL8X6svEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.6.tgz",
+      "integrity": "sha512-xzThn87Pf3YrOGTEODFGONmqXpTwUNxovQb72iaUOdcw8sBSY3+3WD8Hm9IhMYLnPi0n32s3L3NWU6+eSjfqFg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.6.tgz",
+      "integrity": "sha512-7++XhnsPlr1HDbor5amovPjOH6vsrFOCdp93iKXhFn6bcMUI6soodj3WWKfgEO6JosKU1W5n3uky3WW9RlRjTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   ],
   "scripts": {
     "build": "tsc",
+    "lint": "biome check src/",
+    "lint:fix": "biome check --write src/",
     "test": "vitest run",
     "start": "node dist/index.js",
     "dev": "node --watch --experimental-strip-types src/index.ts",
@@ -49,6 +51,7 @@
     "zod": "^3.25.0"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.6",
     "@types/node": "^22.0.0",
     "typescript": "~5.9.3",
     "vitest": "^3.0.0"

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -10,7 +10,11 @@
  */
 
 import type { AppConfig } from "./config.js";
-import { KomodoError, registerSensitivePattern, sanitizeMessage } from "./errors.js";
+import {
+  KomodoError,
+  registerSensitivePattern,
+  sanitizeMessage,
+} from "./errors.js";
 import { logger } from "./logger.js";
 
 /** Request timeout in milliseconds. */
@@ -72,7 +76,7 @@ export class KomodoClient {
         );
       }
 
-      const data = await response.json() as { version?: string };
+      const data = (await response.json()) as { version?: string };
       logger.info(
         `Connected to Komodo at ${this.baseUrl} (version: ${data.version ?? "unknown"})`,
       );
@@ -108,7 +112,7 @@ export class KomodoClient {
       if (!response.ok) {
         let detail = `${response.status} ${response.statusText}`;
         try {
-          const errBody = await response.json() as { error?: string };
+          const errBody = (await response.json()) as { error?: string };
           if (errBody.error) {
             detail += ` — ${errBody.error}`;
           }
@@ -125,9 +129,7 @@ export class KomodoClient {
     } catch (err) {
       if (err instanceof KomodoError) throw err;
       throw new KomodoError(
-        sanitizeMessage(
-          err instanceof Error ? err.message : String(err),
-        ),
+        sanitizeMessage(err instanceof Error ? err.message : String(err)),
       );
     }
   }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -3,7 +3,7 @@
  * Reads required and optional config from process.env.
  */
 
-import type { AccessTier } from '../types/index.js';
+import type { AccessTier } from "../types/index.js";
 
 export interface AppConfig {
   url: string;
@@ -15,7 +15,7 @@ export interface AppConfig {
   toolWhitelist: string[] | null;
   excludeToolTitles: boolean;
   debug: boolean;
-  transport: 'stdio' | 'http';
+  transport: "stdio" | "http";
   httpPort: number;
   httpHost: string;
 }
@@ -35,21 +35,21 @@ function parseAccessTier(): AccessTier {
 }
 
 function parseCategories(value: string | undefined): string[] | null {
-  if (value === undefined || value === '') {
+  if (value === undefined || value === "") {
     return null;
   }
   return value
-    .split(',')
+    .split(",")
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
 }
 
 function parseToolList(value: string | undefined): string[] | null {
-  if (value === undefined || value === '') {
+  if (value === undefined || value === "") {
     return null;
   }
   return value
-    .split(',')
+    .split(",")
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
 }
@@ -67,35 +67,36 @@ export function loadConfig(): AppConfig {
   const apiKey = process.env.KOMODO_API_KEY;
   const apiSecret = process.env.KOMODO_API_SECRET;
 
-  const missing: string[] = [];
-  if (!url) missing.push('KOMODO_URL');
-  if (!apiKey) missing.push('KOMODO_API_KEY');
-  if (!apiSecret) missing.push('KOMODO_API_SECRET');
-
-  if (missing.length > 0) {
+  if (!url || !apiKey || !apiSecret) {
+    const missing: string[] = [];
+    if (!url) missing.push("KOMODO_URL");
+    if (!apiKey) missing.push("KOMODO_API_KEY");
+    if (!apiSecret) missing.push("KOMODO_API_SECRET");
     throw new Error(
-      `Missing required environment variables: ${missing.join(', ')}. ` +
-        'Set these variables to connect to your Komodo instance.',
+      `Missing required environment variables: ${missing.join(", ")}. ` +
+        "Set these variables to connect to your Komodo instance.",
     );
   }
 
   const excludeToolTitles = process.env.MCP_EXCLUDE_TOOL_TITLES === "true";
 
   const transport =
-    process.env.MCP_TRANSPORT === 'http' ? ('http' as const) : ('stdio' as const);
-  const rawPort = process.env.MCP_PORT ?? '3000';
+    process.env.MCP_TRANSPORT === "http"
+      ? ("http" as const)
+      : ("stdio" as const);
+  const rawPort = process.env.MCP_PORT ?? "3000";
   const httpPort = parseInt(rawPort, 10);
-  if (isNaN(httpPort) || httpPort < 1 || httpPort > 65535) {
+  if (Number.isNaN(httpPort) || httpPort < 1 || httpPort > 65535) {
     throw new Error(
       `Invalid MCP_PORT: "${rawPort}". Must be an integer between 1 and 65535.`,
     );
   }
-  const httpHost = process.env.MCP_HOST ?? '0.0.0.0';
+  const httpHost = process.env.MCP_HOST ?? "0.0.0.0";
 
   return {
-    url: url!.replace(/\/+$/, ''),
-    apiKey: apiKey!,
-    apiSecret: apiSecret!,
+    url: url.replace(/\/+$/, ""),
+    apiKey,
+    apiSecret,
     accessTier: parseAccessTier(),
     categories: parseCategories(process.env.KOMODO_CATEGORIES),
     toolBlacklist: parseToolList(process.env.KOMODO_TOOL_BLACKLIST),

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -30,10 +30,7 @@ export function sanitizeMessage(message: string): string {
     sanitized = sanitized.replaceAll(pattern, "[REDACTED]");
   }
   // Strip common auth header patterns
-  sanitized = sanitized.replace(
-    /x-api-key:\s*\S+/gi,
-    "x-api-key: [REDACTED]",
-  );
+  sanitized = sanitized.replace(/x-api-key:\s*\S+/gi, "x-api-key: [REDACTED]");
   sanitized = sanitized.replace(
     /x-api-secret:\s*\S+/gi,
     "x-api-secret: [REDACTED]",

--- a/src/core/formatters.ts
+++ b/src/core/formatters.ts
@@ -7,43 +7,43 @@
  */
 
 import type {
-  ServerListItem,
-  Server,
-  ServerActionState,
-  SystemStats,
-  SystemInformation,
-  SystemProcess,
-  StackListItem,
-  Stack,
-  StackActionState,
-  StackService,
-  GetStacksSummaryResponse,
-  DeploymentListItem,
-  Deployment,
-  DeploymentActionState,
-  GetDeploymentsSummaryResponse,
-  BuildListItem,
-  Build,
-  BuildActionState,
-  RepoListItem,
-  Repo,
-  RepoActionState,
-  ProcedureListItem,
-  Procedure,
-  ProcedureActionState,
-  ActionListItem,
   Action,
   ActionActionState,
-  BuilderListItem,
-  Builder,
-  AlerterListItem,
+  ActionListItem,
   Alerter,
-  ResourceSyncListItem,
+  AlerterListItem,
+  Build,
+  BuildActionState,
+  Builder,
+  BuilderListItem,
+  BuildListItem,
+  Deployment,
+  DeploymentActionState,
+  DeploymentListItem,
+  GetDeploymentsSummaryResponse,
+  GetStacksSummaryResponse,
+  Log,
+  Procedure,
+  ProcedureActionState,
+  ProcedureListItem,
+  Repo,
+  RepoActionState,
+  RepoListItem,
   ResourceSync,
   ResourceSyncActionState,
-  UpdateListItem,
+  ResourceSyncListItem,
+  Server,
+  ServerActionState,
+  ServerListItem,
+  Stack,
+  StackActionState,
+  StackListItem,
+  StackService,
+  SystemInformation,
+  SystemProcess,
+  SystemStats,
   Update,
-  Log,
+  UpdateListItem,
   Version,
 } from "../types/komodo.js";
 
@@ -189,19 +189,25 @@ export function formatStackDetail(
     const info = stack.info;
     if (info.deployed_project_name)
       sections.push(`Project: ${info.deployed_project_name}`);
-    if (info.deployed_hash) sections.push(`Deployed commit: ${info.deployed_hash}`);
+    if (info.deployed_hash)
+      sections.push(`Deployed commit: ${info.deployed_hash}`);
     if (info.latest_hash) sections.push(`Latest commit: ${info.latest_hash}`);
   }
   if (stack.config) {
     const cfg = stack.config;
     sections.push(`Server: ${cfg.server_id || "unassigned"}`);
-    if (cfg.repo) sections.push(`Repo: ${cfg.git_provider}/${cfg.repo} (branch: ${cfg.branch})`);
+    if (cfg.repo)
+      sections.push(
+        `Repo: ${cfg.git_provider}/${cfg.repo} (branch: ${cfg.branch})`,
+      );
     sections.push(`Auto-pull: ${cfg.auto_pull}`);
     sections.push(`Webhook enabled: ${cfg.webhook_enabled}`);
   }
   if (stack.tags?.length) sections.push(`Tags: ${stack.tags.join(", ")}`);
   if (actionState) {
-    const stateStr = formatActionState(actionState as unknown as Record<string, boolean>);
+    const stateStr = formatActionState(
+      actionState as unknown as Record<string, boolean>,
+    );
     if (stateStr) sections.push(stateStr.trim());
   }
   return sections.join("\n");
@@ -245,9 +251,12 @@ export function formatDeploymentDetail(
     if (cfg.restart) sections.push(`Restart: ${cfg.restart}`);
     sections.push(`Redeploy on build: ${cfg.redeploy_on_build ?? false}`);
   }
-  if (deployment.tags?.length) sections.push(`Tags: ${deployment.tags.join(", ")}`);
+  if (deployment.tags?.length)
+    sections.push(`Tags: ${deployment.tags.join(", ")}`);
   if (actionState) {
-    const stateStr = formatActionState(actionState as unknown as Record<string, boolean>);
+    const stateStr = formatActionState(
+      actionState as unknown as Record<string, boolean>,
+    );
     if (stateStr) sections.push(stateStr.trim());
   }
   return sections.join("\n");
@@ -277,7 +286,10 @@ export function formatBuildDetail(
   ];
   if (build.info) {
     const info = build.info;
-    if (info.last_built_at) sections.push(`Last built: ${new Date(info.last_built_at).toISOString()}`);
+    if (info.last_built_at)
+      sections.push(
+        `Last built: ${new Date(info.last_built_at).toISOString()}`,
+      );
     if (info.built_hash) sections.push(`Built commit: ${info.built_hash}`);
     if (info.latest_hash) sections.push(`Latest commit: ${info.latest_hash}`);
   }
@@ -285,7 +297,10 @@ export function formatBuildDetail(
     const cfg = build.config;
     if (cfg.builder_id) sections.push(`Builder: ${cfg.builder_id}`);
     if (cfg.version) sections.push(`Version: ${formatVersion(cfg.version)}`);
-    if (cfg.repo) sections.push(`Repo: ${cfg.git_provider}/${cfg.repo} (branch: ${cfg.branch})`);
+    if (cfg.repo)
+      sections.push(
+        `Repo: ${cfg.git_provider}/${cfg.repo} (branch: ${cfg.branch})`,
+      );
     sections.push(`Build path: ${cfg.build_path}`);
     sections.push(`Dockerfile: ${cfg.dockerfile_path}`);
   }
@@ -320,20 +335,34 @@ export function formatRepoDetail(
   ];
   if (repo.info) {
     const info = repo.info;
-    if (info.last_pulled_at) sections.push(`Last pulled: ${new Date(info.last_pulled_at).toISOString()}`);
+    if (info.last_pulled_at)
+      sections.push(
+        `Last pulled: ${new Date(info.last_pulled_at).toISOString()}`,
+      );
     if (info.built_hash) sections.push(`Built commit: ${info.built_hash}`);
     if (info.latest_hash) sections.push(`Latest commit: ${info.latest_hash}`);
   }
   if (repo.config) {
     const cfg = repo.config;
     sections.push(`Server: ${cfg.server_id || "unassigned"}`);
-    if (cfg.repo) sections.push(`Repo: ${cfg.git_provider}/${cfg.repo} (branch: ${cfg.branch})`);
-    if (cfg.on_clone) sections.push(`On clone: ${cfg.on_clone.path || ""} ${cfg.on_clone.command || ""}`.trim());
-    if (cfg.on_pull) sections.push(`On pull: ${cfg.on_pull.path || ""} ${cfg.on_pull.command || ""}`.trim());
+    if (cfg.repo)
+      sections.push(
+        `Repo: ${cfg.git_provider}/${cfg.repo} (branch: ${cfg.branch})`,
+      );
+    if (cfg.on_clone)
+      sections.push(
+        `On clone: ${cfg.on_clone.path || ""} ${cfg.on_clone.command || ""}`.trim(),
+      );
+    if (cfg.on_pull)
+      sections.push(
+        `On pull: ${cfg.on_pull.path || ""} ${cfg.on_pull.command || ""}`.trim(),
+      );
   }
   if (repo.tags?.length) sections.push(`Tags: ${repo.tags.join(", ")}`);
   if (actionState) {
-    const stateStr = formatActionState(actionState as unknown as Record<string, boolean>);
+    const stateStr = formatActionState(
+      actionState as unknown as Record<string, boolean>,
+    );
     if (stateStr) sections.push(stateStr.trim());
   }
   return sections.join("\n");
@@ -343,9 +372,7 @@ export function formatRepoDetail(
 // Procedure formatters
 // ---------------------------------------------------------------------------
 
-export function formatProcedureList(
-  procedures: ProcedureListItem[],
-): string {
+export function formatProcedureList(procedures: ProcedureListItem[]): string {
   if (procedures.length === 0) return "No procedures found.";
   const lines = procedures.map(
     (p) =>
@@ -369,12 +396,18 @@ export function formatProcedureDetail(
     sections.push(`Stages: ${stages.length}`);
     for (const stage of stages) {
       const execCount = stage.executions?.length ?? 0;
-      sections.push(`  - ${stage.name}${stage.enabled ? "" : " (disabled)"}: ${execCount} execution(s)`);
+      sections.push(
+        `  - ${stage.name}${stage.enabled ? "" : " (disabled)"}: ${execCount} execution(s)`,
+      );
     }
     sections.push(`Webhook enabled: ${cfg.webhook_enabled}`);
-    if (cfg.schedule) sections.push(`Schedule: ${cfg.schedule}${cfg.schedule_enabled ? "" : " (disabled)"}`);
+    if (cfg.schedule)
+      sections.push(
+        `Schedule: ${cfg.schedule}${cfg.schedule_enabled ? "" : " (disabled)"}`,
+      );
   }
-  if (procedure.tags?.length) sections.push(`Tags: ${procedure.tags.join(", ")}`);
+  if (procedure.tags?.length)
+    sections.push(`Tags: ${procedure.tags.join(", ")}`);
   if (actionState) {
     if (actionState.running) sections.push("Currently: running");
   }
@@ -406,12 +439,16 @@ export function formatActionDetail(
   if (action.config) {
     const cfg = action.config;
     sections.push(`Webhook enabled: ${cfg.webhook_enabled}`);
-    if (cfg.schedule) sections.push(`Schedule: ${cfg.schedule}${cfg.schedule_enabled ? "" : " (disabled)"}`);
+    if (cfg.schedule)
+      sections.push(
+        `Schedule: ${cfg.schedule}${cfg.schedule_enabled ? "" : " (disabled)"}`,
+      );
     sections.push(`Run at startup: ${cfg.run_at_startup}`);
   }
   if (action.tags?.length) sections.push(`Tags: ${action.tags.join(", ")}`);
   if (actionState) {
-    if (actionState.running > 0) sections.push(`Currently: ${actionState.running} instance(s) running`);
+    if (actionState.running > 0)
+      sections.push(`Currently: ${actionState.running} instance(s) running`);
   }
   return sections.join("\n");
 }
@@ -488,9 +525,7 @@ export function formatAlerterDetail(alerter: Alerter): string {
 // ResourceSync formatters
 // ---------------------------------------------------------------------------
 
-export function formatResourceSyncList(
-  syncs: ResourceSyncListItem[],
-): string {
+export function formatResourceSyncList(syncs: ResourceSyncListItem[]): string {
   if (syncs.length === 0) return "No resource syncs found.";
   const lines = syncs.map(
     (s) =>
@@ -510,15 +545,23 @@ export function formatResourceSyncDetail(
   ];
   if (sync.info) {
     const info = sync.info;
-    if (info.last_sync_ts) sections.push(`Last synced: ${new Date(info.last_sync_ts).toISOString()}`);
-    if (info.last_sync_hash) sections.push(`Last sync commit: ${info.last_sync_hash}`);
-    if (info.pending_error) sections.push(`Pending error: ${info.pending_error}`);
+    if (info.last_sync_ts)
+      sections.push(
+        `Last synced: ${new Date(info.last_sync_ts).toISOString()}`,
+      );
+    if (info.last_sync_hash)
+      sections.push(`Last sync commit: ${info.last_sync_hash}`);
+    if (info.pending_error)
+      sections.push(`Pending error: ${info.pending_error}`);
     const updates = info.resource_updates?.length ?? 0;
     if (updates > 0) sections.push(`Pending resource updates: ${updates}`);
   }
   if (sync.config) {
     const cfg = sync.config;
-    if (cfg.repo) sections.push(`Repo: ${cfg.git_provider}/${cfg.repo} (branch: ${cfg.branch})`);
+    if (cfg.repo)
+      sections.push(
+        `Repo: ${cfg.git_provider}/${cfg.repo} (branch: ${cfg.branch})`,
+      );
     const paths = cfg.resource_path ?? [];
     if (paths.length > 0) sections.push(`Resource paths: ${paths.join(", ")}`);
   }
@@ -533,9 +576,7 @@ export function formatResourceSyncDetail(
 // Stack service formatter
 // ---------------------------------------------------------------------------
 
-export function formatStackServiceList(
-  services: StackService[],
-): string {
+export function formatStackServiceList(services: StackService[]): string {
   if (services.length === 0) return "No services found in this stack.";
   const lines = services.map((s) => {
     const parts = [`- ${s.service}`];
@@ -556,9 +597,7 @@ export function formatStackServiceList(
 // Summary formatters
 // ---------------------------------------------------------------------------
 
-export function formatStacksSummary(
-  summary: GetStacksSummaryResponse,
-): string {
+export function formatStacksSummary(summary: GetStacksSummaryResponse): string {
   const lines: string[] = [
     `Stacks summary:`,
     `  Total: ${summary.total}`,
@@ -598,7 +637,8 @@ export function formatUpdateList(
   const lines = updates.map((u) => {
     const time = new Date(u.start_ts).toISOString();
     const status = u.status ?? "Unknown";
-    const result = status === "Complete" ? (u.success ? "OK" : "FAILED") : status;
+    const result =
+      status === "Complete" ? (u.success ? "OK" : "FAILED") : status;
     return `- [${result}] ${u.operation} → ${u.target.type}/${u.target.id} (${time}, by ${u.username || u.operator}) id=${u.id}`;
   });
   let text = `Found ${updates.length} update(s):\n${lines.join("\n")}`;
@@ -617,14 +657,18 @@ export function formatUpdateDetail(update: Update): string {
     `Operator: ${update.operator}`,
     `Started: ${new Date(update.start_ts).toISOString()}`,
   ];
-  if (update.end_ts) sections.push(`Ended: ${new Date(update.end_ts).toISOString()}`);
-  if (update.version) sections.push(`Version: ${formatVersion(update.version)}`);
+  if (update.end_ts)
+    sections.push(`Ended: ${new Date(update.end_ts).toISOString()}`);
+  if (update.version)
+    sections.push(`Version: ${formatVersion(update.version)}`);
   if (update.commit_hash) sections.push(`Commit: ${update.commit_hash}`);
 
   if (update.logs && update.logs.length > 0) {
     sections.push(`\nLogs (${update.logs.length} stage(s)):`);
     for (const log of update.logs) {
-      sections.push(`\n--- [${log.success ? "OK" : "FAILED"}] ${log.stage} ---`);
+      sections.push(
+        `\n--- [${log.success ? "OK" : "FAILED"}] ${log.stage} ---`,
+      );
       if (log.command) sections.push(`Command: ${log.command}`);
       if (log.stdout) sections.push(`stdout:\n${log.stdout}`);
       if (log.stderr) sections.push(`stderr:\n${log.stderr}`);
@@ -663,9 +707,7 @@ export function formatResourceCreated(
   if (resource.description) {
     lines.push(`Description: ${resource.description}`);
   }
-  lines.push(
-    `Use the corresponding get tool to view full details.`,
-  );
+  lines.push(`Use the corresponding get tool to view full details.`);
   return lines.join("\n");
 }
 

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -8,21 +8,21 @@
  * NEVER use console.log() anywhere in this project.
  */
 
-const PREFIX = '[mcp-komodo]';
+const PREFIX = "[mcp-komodo]";
 
 export const logger = {
   info: (...args: unknown[]): void => {
-    console.error(PREFIX, 'INFO', ...args);
+    console.error(PREFIX, "INFO", ...args);
   },
   warn: (...args: unknown[]): void => {
-    console.error(PREFIX, 'WARN', ...args);
+    console.error(PREFIX, "WARN", ...args);
   },
   error: (...args: unknown[]): void => {
-    console.error(PREFIX, 'ERROR', ...args);
+    console.error(PREFIX, "ERROR", ...args);
   },
   debug: (...args: unknown[]): void => {
     if (process.env.DEBUG) {
-      console.error(PREFIX, 'DEBUG', ...args);
+      console.error(PREFIX, "DEBUG", ...args);
     }
   },
 };

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -5,18 +5,18 @@
  * which selects stdio or HTTP transport based on config.
  */
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { randomUUID } from "node:crypto";
 import {
   createServer as createHttpServer,
   type IncomingMessage,
   type ServerResponse,
 } from "node:http";
-import { randomUUID } from "node:crypto";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import pkg from "../../package.json" with { type: "json" };
 import type { AppConfig } from "./config.js";
 import { logger } from "./logger.js";
-import pkg from "../../package.json" with { type: "json" };
 
 const SERVER_NAME = "mcp-komodo";
 
@@ -104,7 +104,9 @@ async function startHttpServer(
           if (!res.headersSent) {
             const status = err instanceof SyntaxError ? 400 : 500;
             const message =
-              err instanceof SyntaxError ? "Invalid JSON" : "Internal server error";
+              err instanceof SyntaxError
+                ? "Invalid JSON"
+                : "Internal server error";
             res.writeHead(status, { "Content-Type": "application/json" });
             res.end(JSON.stringify({ error: message }));
           }

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -17,7 +17,7 @@ import { logger } from "./logger.js";
 const TIER_LEVELS: Record<AccessTier, number> = {
   "read-only": 0,
   "read-execute": 1,
-  "full": 2,
+  full: 2,
 };
 
 export interface ToolRegistrationOptions {
@@ -59,10 +59,8 @@ export function registerTool(
 ): boolean {
   seenToolNames.add(options.name);
 
-  const isBlacklisted =
-    config.toolBlacklist !== null && config.toolBlacklist.includes(options.name);
-  const isWhitelisted =
-    config.toolWhitelist !== null && config.toolWhitelist.includes(options.name);
+  const isBlacklisted = config.toolBlacklist?.includes(options.name);
+  const isWhitelisted = config.toolWhitelist?.includes(options.name);
 
   // Blacklist always wins
   if (isBlacklisted) {
@@ -85,7 +83,10 @@ export function registerTool(
       return false;
     }
 
-    if (config.categories !== null && !config.categories.includes(options.category)) {
+    if (
+      config.categories !== null &&
+      !config.categories.includes(options.category)
+    ) {
       logger.debug(
         `Skipping tool "${options.name}" (category "${options.category}" not in allowed categories)`,
       );
@@ -114,9 +115,13 @@ export function registerTool(
     toolConfig.inputSchema = options.inputSchema;
   }
 
-  server.registerTool(options.name, toolConfig, async (args: Record<string, unknown>) => {
-    return options.handler(args);
-  });
+  server.registerTool(
+    options.name,
+    toolConfig,
+    async (args: Record<string, unknown>) => {
+      return options.handler(args);
+    },
+  );
 
   return true;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,11 +9,12 @@
  * 3. Create MCP server, register tools, start stdio transport
  */
 
-import { loadConfig } from "./core/config.js";
 import { createClient, validateConnection } from "./core/client.js";
+import type { AppConfig } from "./core/config.js";
+import { loadConfig } from "./core/config.js";
+import { logger } from "./core/logger.js";
 import { createServer, startServer } from "./core/server.js";
 import { registerAllTools } from "./tools/index.js";
-import { logger } from "./core/logger.js";
 
 // Process lifecycle handlers -- catch uncaught errors to stderr
 // to prevent them from corrupting the stdout JSON-RPC stream.
@@ -28,7 +29,7 @@ process.on("unhandledRejection", (reason) => {
 });
 
 async function main(): Promise<void> {
-  let config;
+  let config: AppConfig;
   try {
     config = loadConfig();
   } catch (err) {

--- a/src/tests/handlers.test.ts
+++ b/src/tests/handlers.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { KomodoClient } from "../core/client.js";
 import { createServer } from "../core/server.js";
 import { registerAllTools } from "../tools/index.js";
-import { makeConfig, makeMockClient, connectTestClient } from "./helpers.js";
-import type { KomodoClient } from "../core/client.js";
-import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { connectTestClient, makeConfig, makeMockClient } from "./helpers.js";
 
 describe("handler: komodo_list_servers", () => {
   let cleanup: () => Promise<void>;
@@ -40,7 +40,9 @@ describe("handler: komodo_list_servers", () => {
   });
 
   it("returns isError when client throws", async () => {
-    vi.mocked(mockClient.read).mockRejectedValueOnce(new Error("connection refused"));
+    vi.mocked(mockClient.read).mockRejectedValueOnce(
+      new Error("connection refused"),
+    );
 
     const result = await mcpClient.callTool({
       name: "komodo_list_servers",
@@ -73,7 +75,12 @@ describe("handler: komodo_get_server", () => {
 
   it("calls client.read with correct operations", async () => {
     vi.mocked(mockClient.read)
-      .mockResolvedValueOnce({ name: "srv1", config: {}, info: { status: "OK" }, tags: [] })
+      .mockResolvedValueOnce({
+        name: "srv1",
+        config: {},
+        info: { status: "OK" },
+        tags: [],
+      })
       .mockResolvedValueOnce({ state: "idle" });
 
     const result = await mcpClient.callTool({
@@ -81,8 +88,12 @@ describe("handler: komodo_get_server", () => {
       arguments: { server: "srv1" },
     });
 
-    expect(mockClient.read).toHaveBeenCalledWith("GetServer", { server: "srv1" });
-    expect(mockClient.read).toHaveBeenCalledWith("GetServerActionState", { server: "srv1" });
+    expect(mockClient.read).toHaveBeenCalledWith("GetServer", {
+      server: "srv1",
+    });
+    expect(mockClient.read).toHaveBeenCalledWith("GetServerActionState", {
+      server: "srv1",
+    });
     expect(result.isError).toBeFalsy();
   });
 
@@ -99,7 +110,11 @@ describe("handler: komodo_get_server", () => {
 describe("handler: komodo_prune_docker (read-execute tier)", () => {
   it("is not registered in read-only mode", async () => {
     const server = createServer();
-    registerAllTools(server, makeMockClient(), makeConfig({ accessTier: "read-only" }));
+    registerAllTools(
+      server,
+      makeMockClient(),
+      makeConfig({ accessTier: "read-only" }),
+    );
     const { client, cleanup } = await connectTestClient(server);
     const { tools } = await client.listTools();
     expect(tools.map((t) => t.name)).not.toContain("komodo_prune_docker");
@@ -119,7 +134,9 @@ describe("handler: komodo_prune_docker (read-execute tier)", () => {
     });
 
     expect(result.isError).toBeFalsy();
-    expect(mockClient.execute).toHaveBeenCalledWith("PruneContainers", { server: "srv1" });
+    expect(mockClient.execute).toHaveBeenCalledWith("PruneContainers", {
+      server: "srv1",
+    });
     await cleanup();
   });
 });

--- a/src/tests/helpers.ts
+++ b/src/tests/helpers.ts
@@ -1,9 +1,9 @@
-import { vi } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { AppConfig } from "../core/config.js";
+import { vi } from "vitest";
 import type { KomodoClient } from "../core/client.js";
+import type { AppConfig } from "../core/config.js";
 
 export function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
   return {

--- a/src/tests/registration.test.ts
+++ b/src/tests/registration.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { logger } from "../core/logger.js";
 import { createServer } from "../core/server.js";
 import { registerAllTools } from "../tools/index.js";
-import { logger } from "../core/logger.js";
-import { makeConfig, makeMockClient, connectTestClient } from "./helpers.js";
+import { connectTestClient, makeConfig, makeMockClient } from "./helpers.js";
 
 describe("tool registration", () => {
   it("registers all tools at full tier", async () => {
@@ -16,19 +16,30 @@ describe("tool registration", () => {
 
   it("registers only read-only tools in read-only mode", async () => {
     const server = createServer();
-    registerAllTools(server, makeMockClient(), makeConfig({ accessTier: "read-only" }));
+    registerAllTools(
+      server,
+      makeMockClient(),
+      makeConfig({ accessTier: "read-only" }),
+    );
     const { client, cleanup } = await connectTestClient(server);
     const { tools } = await client.listTools();
     expect(tools).toHaveLength(36);
     for (const tool of tools) {
-      expect(tool.annotations?.readOnlyHint, `${tool.name} missing readOnlyHint`).toBe(true);
+      expect(
+        tool.annotations?.readOnlyHint,
+        `${tool.name} missing readOnlyHint`,
+      ).toBe(true);
     }
     await cleanup();
   });
 
   it("registers read-only + read-execute tools in read-execute mode", async () => {
     const server = createServer();
-    registerAllTools(server, makeMockClient(), makeConfig({ accessTier: "read-execute" }));
+    registerAllTools(
+      server,
+      makeMockClient(),
+      makeConfig({ accessTier: "read-execute" }),
+    );
     const { client, cleanup } = await connectTestClient(server);
     const { tools } = await client.listTools();
     expect(tools).toHaveLength(52);
@@ -37,12 +48,18 @@ describe("tool registration", () => {
 
   it("filters to only servers category tools", async () => {
     const server = createServer();
-    registerAllTools(server, makeMockClient(), makeConfig({ categories: ["servers"] }));
+    registerAllTools(
+      server,
+      makeMockClient(),
+      makeConfig({ categories: ["servers"] }),
+    );
     const { client, cleanup } = await connectTestClient(server);
     const { tools } = await client.listTools();
     expect(tools.length).toBeGreaterThan(0);
     for (const tool of tools) {
-      expect(tool.name).toMatch(/^komodo_.*server|^komodo_inspect_docker|^komodo_prune_docker|^komodo_delete_docker/);
+      expect(tool.name).toMatch(
+        /^komodo_.*server|^komodo_inspect_docker|^komodo_prune_docker|^komodo_delete_docker/,
+      );
     }
     await cleanup();
   });
@@ -54,7 +71,11 @@ describe("tool registration", () => {
     const { tools: allTools } = await fullConn.client.listTools();
 
     const filteredServer = createServer();
-    registerAllTools(filteredServer, makeMockClient(), makeConfig({ categories: ["servers", "stacks"] }));
+    registerAllTools(
+      filteredServer,
+      makeMockClient(),
+      makeConfig({ categories: ["servers", "stacks"] }),
+    );
     const filteredConn = await connectTestClient(filteredServer);
     const { tools: filteredTools } = await filteredConn.client.listTools();
 
@@ -79,11 +100,18 @@ describe("tool registration", () => {
 
     it("excludes titles when excludeToolTitles is true", async () => {
       const server = createServer();
-      registerAllTools(server, makeMockClient(), makeConfig({ excludeToolTitles: true }));
+      registerAllTools(
+        server,
+        makeMockClient(),
+        makeConfig({ excludeToolTitles: true }),
+      );
       const { client, cleanup } = await connectTestClient(server);
       const { tools } = await client.listTools();
       for (const tool of tools) {
-        expect(tool.title, `${tool.name} should not have title`).toBeUndefined();
+        expect(
+          tool.title,
+          `${tool.name} should not have title`,
+        ).toBeUndefined();
       }
       await cleanup();
     });
@@ -92,7 +120,11 @@ describe("tool registration", () => {
   describe("blacklist/whitelist", () => {
     it("blacklist excludes specific tools", async () => {
       const server = createServer();
-      registerAllTools(server, makeMockClient(), makeConfig({ toolBlacklist: ["komodo_list_servers"] }));
+      registerAllTools(
+        server,
+        makeMockClient(),
+        makeConfig({ toolBlacklist: ["komodo_list_servers"] }),
+      );
       const { client, cleanup } = await connectTestClient(server);
       const { tools } = await client.listTools();
       const names = tools.map((t) => t.name);
@@ -102,7 +134,11 @@ describe("tool registration", () => {
 
     it("blacklist does not affect non-blacklisted tools", async () => {
       const server = createServer();
-      registerAllTools(server, makeMockClient(), makeConfig({ toolBlacklist: ["komodo_list_servers"] }));
+      registerAllTools(
+        server,
+        makeMockClient(),
+        makeConfig({ toolBlacklist: ["komodo_list_servers"] }),
+      );
       const { client, cleanup } = await connectTestClient(server);
       const { tools } = await client.listTools();
       const names = tools.map((t) => t.name);
@@ -112,10 +148,14 @@ describe("tool registration", () => {
 
     it("whitelist includes tool excluded by tier filter", async () => {
       const server = createServer();
-      registerAllTools(server, makeMockClient(), makeConfig({
-        accessTier: "read-only",
-        toolWhitelist: ["komodo_write_resource"],
-      }));
+      registerAllTools(
+        server,
+        makeMockClient(),
+        makeConfig({
+          accessTier: "read-only",
+          toolWhitelist: ["komodo_write_resource"],
+        }),
+      );
       const { client, cleanup } = await connectTestClient(server);
       const { tools } = await client.listTools();
       const names = tools.map((t) => t.name);
@@ -125,10 +165,14 @@ describe("tool registration", () => {
 
     it("whitelist includes tool excluded by category filter", async () => {
       const server = createServer();
-      registerAllTools(server, makeMockClient(), makeConfig({
-        categories: ["servers"],
-        toolWhitelist: ["komodo_list_stacks"],
-      }));
+      registerAllTools(
+        server,
+        makeMockClient(),
+        makeConfig({
+          categories: ["servers"],
+          toolWhitelist: ["komodo_list_stacks"],
+        }),
+      );
       const { client, cleanup } = await connectTestClient(server);
       const { tools } = await client.listTools();
       const names = tools.map((t) => t.name);
@@ -138,10 +182,14 @@ describe("tool registration", () => {
 
     it("blacklist takes precedence over whitelist", async () => {
       const server = createServer();
-      registerAllTools(server, makeMockClient(), makeConfig({
-        toolBlacklist: ["komodo_list_servers"],
-        toolWhitelist: ["komodo_list_servers"],
-      }));
+      registerAllTools(
+        server,
+        makeMockClient(),
+        makeConfig({
+          toolBlacklist: ["komodo_list_servers"],
+          toolWhitelist: ["komodo_list_servers"],
+        }),
+      );
       const { client, cleanup } = await connectTestClient(server);
       const { tools } = await client.listTools();
       const names = tools.map((t) => t.name);
@@ -152,31 +200,49 @@ describe("tool registration", () => {
     it("blacklist + whitelist conflict logs warning", async () => {
       const spy = vi.spyOn(logger, "warn");
       const server = createServer();
-      registerAllTools(server, makeMockClient(), makeConfig({
-        toolBlacklist: ["komodo_list_servers"],
-        toolWhitelist: ["komodo_list_servers"],
-      }));
-      expect(spy).toHaveBeenCalledWith(expect.stringContaining("blacklist takes precedence"));
+      registerAllTools(
+        server,
+        makeMockClient(),
+        makeConfig({
+          toolBlacklist: ["komodo_list_servers"],
+          toolWhitelist: ["komodo_list_servers"],
+        }),
+      );
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining("blacklist takes precedence"),
+      );
       spy.mockRestore();
     });
 
     it("validates unknown blacklisted tool name", async () => {
       const spy = vi.spyOn(logger, "warn");
       const server = createServer();
-      registerAllTools(server, makeMockClient(), makeConfig({
-        toolBlacklist: ["nonexistent_tool_xyz"],
-      }));
-      expect(spy).toHaveBeenCalledWith(expect.stringContaining("does not match"));
+      registerAllTools(
+        server,
+        makeMockClient(),
+        makeConfig({
+          toolBlacklist: ["nonexistent_tool_xyz"],
+        }),
+      );
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining("does not match"),
+      );
       spy.mockRestore();
     });
 
     it("validates unknown whitelisted tool name", async () => {
       const spy = vi.spyOn(logger, "warn");
       const server = createServer();
-      registerAllTools(server, makeMockClient(), makeConfig({
-        toolWhitelist: ["nonexistent_tool_abc"],
-      }));
-      expect(spy).toHaveBeenCalledWith(expect.stringContaining("does not match"));
+      registerAllTools(
+        server,
+        makeMockClient(),
+        makeConfig({
+          toolWhitelist: ["nonexistent_tool_abc"],
+        }),
+      );
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining("does not match"),
+      );
       spy.mockRestore();
     });
   });
@@ -189,9 +255,9 @@ describe("tool registration", () => {
       const { tools } = await client.listTools();
       const tool = tools.find((t) => t.name === "komodo_list_servers");
       expect(tool).toBeDefined();
-      expect(tool!.annotations?.readOnlyHint).toBe(true);
-      expect(tool!.annotations?.destructiveHint).toBe(false);
-      expect(tool!.annotations?.idempotentHint).toBe(true);
+      expect(tool?.annotations?.readOnlyHint).toBe(true);
+      expect(tool?.annotations?.destructiveHint).toBe(false);
+      expect(tool?.annotations?.idempotentHint).toBe(true);
       await cleanup();
     });
 
@@ -202,9 +268,9 @@ describe("tool registration", () => {
       const { tools } = await client.listTools();
       const tool = tools.find((t) => t.name === "komodo_prune_docker");
       expect(tool).toBeDefined();
-      expect(tool!.annotations?.readOnlyHint).toBe(false);
-      expect(tool!.annotations?.destructiveHint).toBe(true);
-      expect(tool!.annotations?.idempotentHint).toBe(true);
+      expect(tool?.annotations?.readOnlyHint).toBe(false);
+      expect(tool?.annotations?.destructiveHint).toBe(true);
+      expect(tool?.annotations?.idempotentHint).toBe(true);
       await cleanup();
     });
   });

--- a/src/tools/actions.ts
+++ b/src/tools/actions.ts
@@ -5,19 +5,23 @@
  * An Action is a custom TypeScript/Deno script that runs on Komodo Core.
  */
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
 import {
-  formatActionList,
   formatActionDetail,
+  formatActionList,
   formatUpdateCreated,
 } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
 
-export function registerActionTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
+export function registerActionTools(
+  server: McpServer,
+  client: KomodoClient,
+  config: AppConfig,
+): void {
   // -------------------------------------------------------------------------
   // komodo_list_actions
   // -------------------------------------------------------------------------
@@ -124,10 +128,7 @@ export function registerActionTools(server: McpServer, client: KomodoClient, con
           content: [
             {
               type: "text" as const,
-              text: formatUpdateCreated(
-                update,
-                `Running action '${action}'`,
-              ),
+              text: formatUpdateCreated(update, `Running action '${action}'`),
             },
           ],
         };

--- a/src/tools/alerters.ts
+++ b/src/tools/alerters.ts
@@ -6,15 +6,19 @@
  * for Komodo alerts and status changes.
  */
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
-import { formatAlerterList, formatAlerterDetail } from "../core/formatters.js";
+import { formatAlerterDetail, formatAlerterList } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
 
-export function registerAlerterTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
+export function registerAlerterTools(
+  server: McpServer,
+  client: KomodoClient,
+  config: AppConfig,
+): void {
   // -------------------------------------------------------------------------
   // komodo_list_alerters
   // -------------------------------------------------------------------------

--- a/src/tools/builders.ts
+++ b/src/tools/builders.ts
@@ -6,15 +6,19 @@
  * Docker images for Komodo Builds.
  */
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
-import { formatBuilderList, formatBuilderDetail } from "../core/formatters.js";
+import { formatBuilderDetail, formatBuilderList } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
 
-export function registerBuilderTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
+export function registerBuilderTools(
+  server: McpServer,
+  client: KomodoClient,
+  config: AppConfig,
+): void {
   // -------------------------------------------------------------------------
   // komodo_list_builders
   // -------------------------------------------------------------------------

--- a/src/tools/builds.ts
+++ b/src/tools/builds.ts
@@ -6,19 +6,23 @@
  * into container images using a configured Builder.
  */
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
 import {
-  formatBuildList,
   formatBuildDetail,
+  formatBuildList,
   formatUpdateCreated,
 } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
 
-export function registerBuildTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
+export function registerBuildTools(
+  server: McpServer,
+  client: KomodoClient,
+  config: AppConfig,
+): void {
   // -------------------------------------------------------------------------
   // komodo_list_builds
   // -------------------------------------------------------------------------
@@ -164,10 +168,7 @@ export function registerBuildTools(server: McpServer, client: KomodoClient, conf
           content: [
             {
               type: "text" as const,
-              text: formatUpdateCreated(
-                update,
-                `Cancelling build '${build}'`,
-              ),
+              text: formatUpdateCreated(update, `Cancelling build '${build}'`),
             },
           ],
         };

--- a/src/tools/containers.ts
+++ b/src/tools/containers.ts
@@ -6,16 +6,20 @@
  * unlike deployment/stack logs which only need the resource name.
  */
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { SearchCombinator } from "../types/komodo.js";
 import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
 import { formatLog } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
+import { SearchCombinator } from "../types/komodo.js";
 
-export function registerContainerTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
+export function registerContainerTools(
+  server: McpServer,
+  client: KomodoClient,
+  config: AppConfig,
+): void {
   // -------------------------------------------------------------------------
   // komodo_get_container_log
   // -------------------------------------------------------------------------
@@ -43,9 +47,7 @@ export function registerContainerTools(server: McpServer, client: KomodoClient, 
         .min(1)
         .max(5000)
         .optional()
-        .describe(
-          "Number of log lines to return (default: 50, max: 5000)",
-        ),
+        .describe("Number of log lines to return (default: 50, max: 5000)"),
       search_terms: z
         .array(z.string())
         .optional()
@@ -62,21 +64,19 @@ export function registerContainerTools(server: McpServer, client: KomodoClient, 
       const search_terms = args.search_terms as string[] | undefined;
       const search_combinator = args.search_combinator as string | undefined;
       try {
-        let log;
-        if (search_terms && search_terms.length > 0) {
-          log = await client.read("SearchContainerLog", {
-            server: serverParam,
-            container,
-            terms: search_terms,
-            combinator: (search_combinator as SearchCombinator) || SearchCombinator.Or,
-          });
-        } else {
-          log = await client.read("GetContainerLog", {
-            server: serverParam,
-            container,
-            tail: tail ?? 50,
-          });
-        }
+        const log = search_terms?.length
+          ? await client.read("SearchContainerLog", {
+              server: serverParam,
+              container,
+              terms: search_terms,
+              combinator:
+                (search_combinator as SearchCombinator) || SearchCombinator.Or,
+            })
+          : await client.read("GetContainerLog", {
+              server: serverParam,
+              container,
+              tail: tail ?? 50,
+            });
         return {
           content: [{ type: "text" as const, text: formatLog(log) }],
         };

--- a/src/tools/deployments.ts
+++ b/src/tools/deployments.ts
@@ -7,22 +7,26 @@
  * deployed to a specific server.
  */
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { SearchCombinator } from "../types/komodo.js";
 import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
 import {
-  formatDeploymentList,
   formatDeploymentDetail,
+  formatDeploymentList,
   formatDeploymentsSummary,
   formatLog,
   formatUpdateCreated,
 } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
+import { SearchCombinator } from "../types/komodo.js";
 
-export function registerDeploymentTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
+export function registerDeploymentTools(
+  server: McpServer,
+  client: KomodoClient,
+  config: AppConfig,
+): void {
   // -------------------------------------------------------------------------
   // komodo_list_deployments
   // -------------------------------------------------------------------------
@@ -97,10 +101,7 @@ export function registerDeploymentTools(server: McpServer, client: KomodoClient,
           ],
         };
       } catch (error) {
-        return handleKomodoError(
-          `getting deployment '${deployment}'`,
-          error,
-        );
+        return handleKomodoError(`getting deployment '${deployment}'`, error);
       }
     },
   });
@@ -130,9 +131,7 @@ export function registerDeploymentTools(server: McpServer, client: KomodoClient,
         .min(1)
         .max(5000)
         .optional()
-        .describe(
-          "Number of log lines to return (default: 50, max: 5000)",
-        ),
+        .describe("Number of log lines to return (default: 50, max: 5000)"),
       search_terms: z
         .array(z.string())
         .optional()
@@ -142,7 +141,7 @@ export function registerDeploymentTools(server: McpServer, client: KomodoClient,
         .optional()
         .describe(
           "How to combine search terms: 'And' = all terms must match, " +
-          "'Or' = any term matches (default: 'Or')",
+            "'Or' = any term matches (default: 'Or')",
         ),
     },
     handler: async (args) => {
@@ -151,19 +150,17 @@ export function registerDeploymentTools(server: McpServer, client: KomodoClient,
       const search_terms = args.search_terms as string[] | undefined;
       const search_combinator = args.search_combinator as string | undefined;
       try {
-        let log;
-        if (search_terms && search_terms.length > 0) {
-          log = await client.read("SearchDeploymentLog", {
-            deployment,
-            terms: search_terms,
-            combinator: (search_combinator as SearchCombinator) || SearchCombinator.Or,
-          });
-        } else {
-          log = await client.read("GetDeploymentLog", {
-            deployment,
-            tail: tail || 50,
-          });
-        }
+        const log = search_terms?.length
+          ? await client.read("SearchDeploymentLog", {
+              deployment,
+              terms: search_terms,
+              combinator:
+                (search_combinator as SearchCombinator) || SearchCombinator.Or,
+            })
+          : await client.read("GetDeploymentLog", {
+              deployment,
+              tail: tail || 50,
+            });
         return {
           content: [{ type: "text" as const, text: formatLog(log) }],
         };
@@ -199,12 +196,19 @@ export function registerDeploymentTools(server: McpServer, client: KomodoClient,
     handler: async (args) => {
       const deployment = args.deployment as string;
       try {
-        const container = await client.read("InspectDeploymentContainer", { deployment });
+        const container = await client.read("InspectDeploymentContainer", {
+          deployment,
+        });
         return {
-          content: [{ type: "text" as const, text: JSON.stringify(container, null, 2) }],
+          content: [
+            { type: "text" as const, text: JSON.stringify(container, null, 2) },
+          ],
         };
       } catch (error) {
-        return handleKomodoError(`inspecting container for deployment '${deployment}'`, error);
+        return handleKomodoError(
+          `inspecting container for deployment '${deployment}'`,
+          error,
+        );
       }
     },
   });
@@ -280,10 +284,7 @@ export function registerDeploymentTools(server: McpServer, client: KomodoClient,
           ],
         };
       } catch (error) {
-        return handleKomodoError(
-          `deploying deployment '${deployment}'`,
-          error,
-        );
+        return handleKomodoError(`deploying deployment '${deployment}'`, error);
       }
     },
   });
@@ -363,7 +364,12 @@ export function registerDeploymentTools(server: McpServer, client: KomodoClient,
     },
     handler: async (args) => {
       const deployment = args.deployment as string;
-      const action = args.action as "start" | "stop" | "restart" | "pause" | "unpause";
+      const action = args.action as
+        | "start"
+        | "stop"
+        | "restart"
+        | "pause"
+        | "unpause";
       try {
         const operationMap = {
           start: "StartDeployment",
@@ -387,10 +393,7 @@ export function registerDeploymentTools(server: McpServer, client: KomodoClient,
           ],
         };
       } catch (error) {
-        return handleKomodoError(
-          `${action} deployment '${deployment}'`,
-          error,
-        );
+        return handleKomodoError(`${action} deployment '${deployment}'`, error);
       }
     },
   });

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -5,21 +5,21 @@
  * registerAllTools() function that wires them into the MCP server.
  */
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { validateToolLists } from "../core/tools.js";
+import { registerActionTools } from "./actions.js";
+import { registerAlerterTools } from "./alerters.js";
+import { registerBuilderTools } from "./builders.js";
+import { registerBuildTools } from "./builds.js";
+import { registerContainerTools } from "./containers.js";
+import { registerDeploymentTools } from "./deployments.js";
+import { registerProcedureTools } from "./procedures.js";
+import { registerRepoTools } from "./repos.js";
+import { registerResourceSyncTools } from "./resource-syncs.js";
 import { registerServerTools } from "./servers.js";
 import { registerStackTools } from "./stacks.js";
-import { registerDeploymentTools } from "./deployments.js";
-import { registerContainerTools } from "./containers.js";
-import { registerBuildTools } from "./builds.js";
-import { registerRepoTools } from "./repos.js";
-import { registerProcedureTools } from "./procedures.js";
-import { registerActionTools } from "./actions.js";
-import { registerBuilderTools } from "./builders.js";
-import { registerAlerterTools } from "./alerters.js";
-import { registerResourceSyncTools } from "./resource-syncs.js";
 import { registerUpdateTools } from "./updates.js";
 import { registerWriteTools } from "./write.js";
 

--- a/src/tools/procedures.ts
+++ b/src/tools/procedures.ts
@@ -6,19 +6,23 @@
  * other Komodo operations (deploy, build, pull, etc.).
  */
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
 import {
-  formatProcedureList,
   formatProcedureDetail,
+  formatProcedureList,
   formatUpdateCreated,
 } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
 
-export function registerProcedureTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
+export function registerProcedureTools(
+  server: McpServer,
+  client: KomodoClient,
+  config: AppConfig,
+): void {
   // -------------------------------------------------------------------------
   // komodo_list_procedures
   // -------------------------------------------------------------------------
@@ -38,10 +42,7 @@ export function registerProcedureTools(server: McpServer, client: KomodoClient, 
       idempotentHint: true,
     },
     inputSchema: {
-      tag: z
-        .string()
-        .optional()
-        .describe("Filter procedures by tag name"),
+      tag: z.string().optional().describe("Filter procedures by tag name"),
     },
     handler: async (args) => {
       const tag = args.tag as string | undefined;
@@ -96,10 +97,7 @@ export function registerProcedureTools(server: McpServer, client: KomodoClient, 
           ],
         };
       } catch (error) {
-        return handleKomodoError(
-          `getting procedure '${procedure}'`,
-          error,
-        );
+        return handleKomodoError(`getting procedure '${procedure}'`, error);
       }
     },
   });
@@ -143,10 +141,7 @@ export function registerProcedureTools(server: McpServer, client: KomodoClient, 
           ],
         };
       } catch (error) {
-        return handleKomodoError(
-          `running procedure '${procedure}'`,
-          error,
-        );
+        return handleKomodoError(`running procedure '${procedure}'`, error);
       }
     },
   });

--- a/src/tools/repos.ts
+++ b/src/tools/repos.ts
@@ -6,19 +6,23 @@
  * using a Builder.
  */
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
 import {
-  formatRepoList,
   formatRepoDetail,
+  formatRepoList,
   formatUpdateCreated,
 } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
 
-export function registerRepoTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
+export function registerRepoTools(
+  server: McpServer,
+  client: KomodoClient,
+  config: AppConfig,
+): void {
   // -------------------------------------------------------------------------
   // komodo_list_repos
   // -------------------------------------------------------------------------
@@ -134,10 +138,7 @@ export function registerRepoTools(server: McpServer, client: KomodoClient, confi
           content: [
             {
               type: "text" as const,
-              text: formatUpdateCreated(
-                update,
-                `${action} repo '${repo}'`,
-              ),
+              text: formatUpdateCreated(update, `${action} repo '${repo}'`),
             },
           ],
         };

--- a/src/tools/resource-syncs.ts
+++ b/src/tools/resource-syncs.ts
@@ -6,19 +6,23 @@
  * TOML configuration files in a Git repository.
  */
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
 import {
-  formatResourceSyncList,
   formatResourceSyncDetail,
+  formatResourceSyncList,
   formatUpdateCreated,
 } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
 
-export function registerResourceSyncTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
+export function registerResourceSyncTools(
+  server: McpServer,
+  client: KomodoClient,
+  config: AppConfig,
+): void {
   // -------------------------------------------------------------------------
   // komodo_list_resource_syncs
   // -------------------------------------------------------------------------
@@ -37,10 +41,7 @@ export function registerResourceSyncTools(server: McpServer, client: KomodoClien
       idempotentHint: true,
     },
     inputSchema: {
-      tag: z
-        .string()
-        .optional()
-        .describe("Filter resource syncs by tag name"),
+      tag: z.string().optional().describe("Filter resource syncs by tag name"),
     },
     handler: async (args) => {
       const tag = args.tag as string | undefined;
@@ -146,10 +147,7 @@ export function registerResourceSyncTools(server: McpServer, client: KomodoClien
           ],
         };
       } catch (error) {
-        return handleKomodoError(
-          `triggering sync '${resource_sync}'`,
-          error,
-        );
+        return handleKomodoError(`triggering sync '${resource_sync}'`, error);
       }
     },
   });

--- a/src/tools/servers.ts
+++ b/src/tools/servers.ts
@@ -5,22 +5,26 @@
  * A Server is a remote machine managed by Komodo's Periphery agent.
  */
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
 import {
-  formatServerList,
-  formatServerDetail,
-  formatSystemStats,
-  formatSystemInfo,
   formatProcessList,
+  formatServerDetail,
+  formatServerList,
+  formatSystemInfo,
+  formatSystemStats,
   formatUpdateCreated,
 } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
 
-export function registerServerTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
+export function registerServerTools(
+  server: McpServer,
+  client: KomodoClient,
+  config: AppConfig,
+): void {
   // -------------------------------------------------------------------------
   // komodo_list_servers
   // -------------------------------------------------------------------------
@@ -92,10 +96,7 @@ export function registerServerTools(server: McpServer, client: KomodoClient, con
           ],
         };
       } catch (error) {
-        return handleKomodoError(
-          `getting server '${serverParam}'`,
-          error,
-        );
+        return handleKomodoError(`getting server '${serverParam}'`, error);
       }
     },
   });
@@ -128,9 +129,7 @@ export function registerServerTools(server: McpServer, client: KomodoClient, con
           server: serverParam,
         });
         return {
-          content: [
-            { type: "text" as const, text: formatSystemStats(stats) },
-          ],
+          content: [{ type: "text" as const, text: formatSystemStats(stats) }],
         };
       } catch (error) {
         return handleKomodoError(
@@ -207,12 +206,20 @@ export function registerServerTools(server: McpServer, client: KomodoClient, con
       const serverParam = args.server as string;
       const container = args.container as string;
       try {
-        const result = await client.read("InspectDockerContainer", { server: serverParam, container });
+        const result = await client.read("InspectDockerContainer", {
+          server: serverParam,
+          container,
+        });
         return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          content: [
+            { type: "text" as const, text: JSON.stringify(result, null, 2) },
+          ],
         };
       } catch (error) {
-        return handleKomodoError(`inspecting container '${container}' on server '${serverParam}'`, error);
+        return handleKomodoError(
+          `inspecting container '${container}' on server '${serverParam}'`,
+          error,
+        );
       }
     },
   });
@@ -242,12 +249,20 @@ export function registerServerTools(server: McpServer, client: KomodoClient, con
       const serverParam = args.server as string;
       const image = args.image as string;
       try {
-        const result = await client.read("InspectDockerImage", { server: serverParam, image });
+        const result = await client.read("InspectDockerImage", {
+          server: serverParam,
+          image,
+        });
         return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          content: [
+            { type: "text" as const, text: JSON.stringify(result, null, 2) },
+          ],
         };
       } catch (error) {
-        return handleKomodoError(`inspecting image '${image}' on server '${serverParam}'`, error);
+        return handleKomodoError(
+          `inspecting image '${image}' on server '${serverParam}'`,
+          error,
+        );
       }
     },
   });
@@ -277,12 +292,20 @@ export function registerServerTools(server: McpServer, client: KomodoClient, con
       const serverParam = args.server as string;
       const network = args.network as string;
       try {
-        const result = await client.read("InspectDockerNetwork", { server: serverParam, network });
+        const result = await client.read("InspectDockerNetwork", {
+          server: serverParam,
+          network,
+        });
         return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          content: [
+            { type: "text" as const, text: JSON.stringify(result, null, 2) },
+          ],
         };
       } catch (error) {
-        return handleKomodoError(`inspecting network '${network}' on server '${serverParam}'`, error);
+        return handleKomodoError(
+          `inspecting network '${network}' on server '${serverParam}'`,
+          error,
+        );
       }
     },
   });
@@ -312,12 +335,20 @@ export function registerServerTools(server: McpServer, client: KomodoClient, con
       const serverParam = args.server as string;
       const volume = args.volume as string;
       try {
-        const result = await client.read("InspectDockerVolume", { server: serverParam, volume });
+        const result = await client.read("InspectDockerVolume", {
+          server: serverParam,
+          volume,
+        });
         return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          content: [
+            { type: "text" as const, text: JSON.stringify(result, null, 2) },
+          ],
         };
       } catch (error) {
-        return handleKomodoError(`inspecting volume '${volume}' on server '${serverParam}'`, error);
+        return handleKomodoError(
+          `inspecting volume '${volume}' on server '${serverParam}'`,
+          error,
+        );
       }
     },
   });
@@ -342,9 +373,7 @@ export function registerServerTools(server: McpServer, client: KomodoClient, con
       idempotentHint: true,
     },
     inputSchema: {
-      server: z
-        .string()
-        .describe("Server name or ID to prune resources on"),
+      server: z.string().describe("Server name or ID to prune resources on"),
       resource_type: z
         .enum([
           "containers",
@@ -363,7 +392,13 @@ export function registerServerTools(server: McpServer, client: KomodoClient, con
     },
     handler: async (args) => {
       const serverParam = args.server as string;
-      const resource_type = args.resource_type as "containers" | "images" | "volumes" | "networks" | "buildx" | "system";
+      const resource_type = args.resource_type as
+        | "containers"
+        | "images"
+        | "volumes"
+        | "networks"
+        | "buildx"
+        | "system";
       try {
         const operationMap = {
           containers: "PruneContainers",
@@ -373,10 +408,9 @@ export function registerServerTools(server: McpServer, client: KomodoClient, con
           buildx: "PruneBuildx",
           system: "PruneSystem",
         } as const;
-        const update = await client.execute(
-          operationMap[resource_type],
-          { server: serverParam },
-        );
+        const update = await client.execute(operationMap[resource_type], {
+          server: serverParam,
+        });
         return {
           content: [
             {
@@ -430,7 +464,10 @@ export function registerServerTools(server: McpServer, client: KomodoClient, con
     },
     handler: async (args) => {
       const serverParam = args.server as string;
-      const resource_type = args.resource_type as "image" | "volume" | "network";
+      const resource_type = args.resource_type as
+        | "image"
+        | "volume"
+        | "network";
       const name = args.name as string;
       try {
         const operationMap = {
@@ -438,10 +475,10 @@ export function registerServerTools(server: McpServer, client: KomodoClient, con
           volume: "DeleteVolume",
           network: "DeleteNetwork",
         } as const;
-        const update = await client.execute(
-          operationMap[resource_type],
-          { server: serverParam, name },
-        );
+        const update = await client.execute(operationMap[resource_type], {
+          server: serverParam,
+          name,
+        });
         return {
           content: [
             {

--- a/src/tools/stacks.ts
+++ b/src/tools/stacks.ts
@@ -7,23 +7,27 @@
  * deployed to a specific server.
  */
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { SearchCombinator } from "../types/komodo.js";
 import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
 import {
-  formatStackList,
+  formatLog,
   formatStackDetail,
+  formatStackList,
   formatStackServiceList,
   formatStacksSummary,
-  formatLog,
   formatUpdateCreated,
 } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
+import { SearchCombinator } from "../types/komodo.js";
 
-export function registerStackTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
+export function registerStackTools(
+  server: McpServer,
+  client: KomodoClient,
+  config: AppConfig,
+): void {
   // -------------------------------------------------------------------------
   // komodo_list_stacks
   // -------------------------------------------------------------------------
@@ -124,17 +128,13 @@ export function registerStackTools(server: McpServer, client: KomodoClient, conf
       services: z
         .array(z.string())
         .optional()
-        .describe(
-          "Filter to specific service names (default: all services)",
-        ),
+        .describe("Filter to specific service names (default: all services)"),
       tail: z
         .number()
         .min(1)
         .max(5000)
         .optional()
-        .describe(
-          "Number of log lines to return (default: 50, max: 5000)",
-        ),
+        .describe("Number of log lines to return (default: 50, max: 5000)"),
       search_terms: z
         .array(z.string())
         .optional()
@@ -144,7 +144,7 @@ export function registerStackTools(server: McpServer, client: KomodoClient, conf
         .optional()
         .describe(
           "How to combine search terms: 'And' = all terms must match, " +
-          "'Or' = any term matches (default: 'Or')",
+            "'Or' = any term matches (default: 'Or')",
         ),
     },
     handler: async (args) => {
@@ -154,29 +154,24 @@ export function registerStackTools(server: McpServer, client: KomodoClient, conf
       const search_terms = args.search_terms as string[] | undefined;
       const search_combinator = args.search_combinator as string | undefined;
       try {
-        let log;
-        if (search_terms && search_terms.length > 0) {
-          log = await client.read("SearchStackLog", {
-            stack,
-            services: services || [],
-            terms: search_terms,
-            combinator: (search_combinator as SearchCombinator) || SearchCombinator.Or,
-          });
-        } else {
-          log = await client.read("GetStackLog", {
-            stack,
-            services: services || [],
-            tail: tail || 50,
-          });
-        }
+        const log = search_terms?.length
+          ? await client.read("SearchStackLog", {
+              stack,
+              services: services || [],
+              terms: search_terms,
+              combinator:
+                (search_combinator as SearchCombinator) || SearchCombinator.Or,
+            })
+          : await client.read("GetStackLog", {
+              stack,
+              services: services || [],
+              tail: tail || 50,
+            });
         return {
           content: [{ type: "text" as const, text: formatLog(log) }],
         };
       } catch (error) {
-        return handleKomodoError(
-          `getting logs for stack '${stack}'`,
-          error,
-        );
+        return handleKomodoError(`getting logs for stack '${stack}'`, error);
       }
     },
   });
@@ -206,12 +201,20 @@ export function registerStackTools(server: McpServer, client: KomodoClient, conf
       const stack = args.stack as string;
       const service = args.service as string;
       try {
-        const container = await client.read("InspectStackContainer", { stack, service });
+        const container = await client.read("InspectStackContainer", {
+          stack,
+          service,
+        });
         return {
-          content: [{ type: "text" as const, text: JSON.stringify(container, null, 2) }],
+          content: [
+            { type: "text" as const, text: JSON.stringify(container, null, 2) },
+          ],
         };
       } catch (error) {
-        return handleKomodoError(`inspecting container for service '${service}' in stack '${stack}'`, error);
+        return handleKomodoError(
+          `inspecting container for service '${service}' in stack '${stack}'`,
+          error,
+        );
       }
     },
   });
@@ -400,10 +403,7 @@ export function registerStackTools(server: McpServer, client: KomodoClient, conf
           ],
         };
       } catch (error) {
-        return handleKomodoError(
-          `pulling images for stack '${stack}'`,
-          error,
-        );
+        return handleKomodoError(`pulling images for stack '${stack}'`, error);
       }
     },
   });
@@ -435,7 +435,12 @@ export function registerStackTools(server: McpServer, client: KomodoClient, conf
     },
     handler: async (args) => {
       const stack = args.stack as string;
-      const action = args.action as "start" | "stop" | "restart" | "pause" | "unpause";
+      const action = args.action as
+        | "start"
+        | "stop"
+        | "restart"
+        | "pause"
+        | "unpause";
       try {
         const operationMap = {
           start: "StartStack",
@@ -449,10 +454,7 @@ export function registerStackTools(server: McpServer, client: KomodoClient, conf
           content: [
             {
               type: "text" as const,
-              text: formatUpdateCreated(
-                update,
-                `${action} stack '${stack}'`,
-              ),
+              text: formatUpdateCreated(update, `${action} stack '${stack}'`),
             },
           ],
         };

--- a/src/tools/updates.ts
+++ b/src/tools/updates.ts
@@ -6,18 +6,19 @@
  * stop, build, etc.), including full command logs with stdout/stderr.
  */
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
-import {
-  formatUpdateList,
-  formatUpdateDetail,
-} from "../core/formatters.js";
+import { formatUpdateDetail, formatUpdateList } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
 
-export function registerUpdateTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
+export function registerUpdateTools(
+  server: McpServer,
+  client: KomodoClient,
+  config: AppConfig,
+): void {
   // -------------------------------------------------------------------------
   // komodo_list_updates
   // -------------------------------------------------------------------------
@@ -40,8 +41,16 @@ export function registerUpdateTools(server: McpServer, client: KomodoClient, con
     inputSchema: {
       target_type: z
         .enum([
-          "Server", "Stack", "Deployment", "Build", "Repo",
-          "Procedure", "Action", "Builder", "Alerter", "ResourceSync",
+          "Server",
+          "Stack",
+          "Deployment",
+          "Build",
+          "Repo",
+          "Procedure",
+          "Action",
+          "Builder",
+          "Alerter",
+          "ResourceSync",
           "ServerTemplate",
         ])
         .optional()
@@ -55,19 +64,21 @@ export function registerUpdateTools(server: McpServer, client: KomodoClient, con
         .optional()
         .describe(
           "Filter by operation name (e.g. 'DeployStack', 'Deploy', " +
-          "'RunBuild', 'StartStack', 'PullStack')",
+            "'RunBuild', 'StartStack', 'PullStack')",
         ),
       success: z
         .boolean()
         .optional()
-        .describe("Filter by success status (true = succeeded, false = failed)"),
+        .describe(
+          "Filter by success status (true = succeeded, false = failed)",
+        ),
       page: z
         .number()
         .min(0)
         .optional()
         .describe(
           "Page number for pagination (0 = most recent). Use the " +
-          "next_page value from a previous response to get more results.",
+            "next_page value from a previous response to get more results.",
         ),
     },
     handler: async (args) => {
@@ -80,8 +91,8 @@ export function registerUpdateTools(server: McpServer, client: KomodoClient, con
         const query: Record<string, unknown> = {};
         if (target_type) query["target.type"] = target_type;
         if (target_id) query["target.id"] = target_id;
-        if (operation) query["operation"] = operation;
-        if (success !== undefined) query["success"] = success;
+        if (operation) query.operation = operation;
+        if (success !== undefined) query.success = success;
 
         const response = await client.read("ListUpdates", {
           query: Object.keys(query).length > 0 ? query : undefined,
@@ -121,7 +132,11 @@ export function registerUpdateTools(server: McpServer, client: KomodoClient, con
       idempotentHint: true,
     },
     inputSchema: {
-      id: z.string().describe("Update ID (returned by execute operations or komodo_list_updates)"),
+      id: z
+        .string()
+        .describe(
+          "Update ID (returned by execute operations or komodo_list_updates)",
+        ),
     },
     handler: async (args) => {
       const id = args.id as string;

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -6,15 +6,15 @@
  * This covers all 20 WRITE requirements with a single tool registration.
  */
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { KomodoClient } from "../core/client.js";
 import type { AppConfig } from "../core/config.js";
 import { handleKomodoError } from "../core/errors.js";
 import {
   formatResourceCreated,
-  formatResourceUpdated,
   formatResourceDeleted,
+  formatResourceUpdated,
 } from "../core/formatters.js";
 import { registerTool } from "../core/tools.js";
 
@@ -245,7 +245,10 @@ async function handleDelete(
       content: [
         {
           type: "text" as const,
-          text: formatResourceDeleted(resourceType, { ...result, name: varName }),
+          text: formatResourceDeleted(resourceType, {
+            ...result,
+            name: varName,
+          }),
         },
       ],
     };
@@ -279,7 +282,11 @@ async function handleDelete(
 // Tool registration
 // ---------------------------------------------------------------------------
 
-export function registerWriteTools(server: McpServer, client: KomodoClient, config: AppConfig): void {
+export function registerWriteTools(
+  server: McpServer,
+  client: KomodoClient,
+  config: AppConfig,
+): void {
   registerTool(server, config, {
     name: "komodo_write_resource",
     title: "Write Resource",
@@ -344,7 +351,13 @@ export function registerWriteTools(server: McpServer, client: KomodoClient, conf
           case "create":
             return await handleCreate(client, resource_type, name, writeConfig);
           case "update":
-            return await handleUpdate(client, resource_type, id, name, writeConfig);
+            return await handleUpdate(
+              client,
+              resource_type,
+              id,
+              name,
+              writeConfig,
+            );
           case "delete":
             return await handleDelete(client, resource_type, id, name);
         }


### PR DESCRIPTION
## Summary

- **Added Biome as dev dependency** (`@biomejs/biome@^2.4.6`) with shared `biome.json` config: double quotes, semicolons, 2-space indent, 80-char line width, recommended lint rules (`noExplicitAny` disabled)
- **Added lint scripts** to `package.json`: `lint` (check) and `lint:fix` (auto-fix)
- **Updated CI workflow** (`.github/workflows/publish.yml`): added `npm run lint` step, renamed job from "Build, Test & Typecheck" to "Lint, Test & Typecheck"
- **Applied Biome formatting across all source files**: single quotes → double quotes, alphabetized imports, line wrapping at 80 chars, `isNaN()` → `Number.isNaN()`, optional chaining simplifications, trailing commas enforced
- **No functional changes** — all modifications are formatting/style only; all tests pass