### PR TITLE
feat: add MCP Registry publishing support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,3 +85,24 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
           provenance: false
+
+  mcp-registry:
+    name: Publish to MCP Registry
+    if: github.event_name == 'release'
+    needs: [publish, docker]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,5 @@ USER mcp
 ENV MCP_PORT=3000
 ENV MCP_HOST=0.0.0.0
 EXPOSE 3000
+LABEL io.modelcontextprotocol.server.name="io.github.samik081/mcp-komodo"
 ENTRYPOINT ["node", "dist/index.js"]

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@samik081/mcp-komodo",
+  "mcpName": "io.github.samik081/mcp-komodo",
   "version": "0.5.0",
   "description": "MCP server for the Komodo DevOps platform — manage servers, stacks, deployments, builds, and more through AI coding tools",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,63 @@
+{
+  "name": "io.github.samik081/mcp-komodo",
+  "version": "0.5.0",
+  "title": "Komodo MCP Server",
+  "description": "MCP server for the Komodo DevOps platform — manage servers, stacks, deployments, builds, and more through AI coding tools",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Samik081/mcp-komodo.git"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@samik081/mcp-komodo",
+      "version": "0.5.0",
+      "runtimeHint": "node",
+      "environment_variables": [
+        {
+          "name": "KOMODO_URL",
+          "description": "URL of the Komodo instance (e.g. https://komodo.example.com)",
+          "required": true
+        },
+        {
+          "name": "KOMODO_API_KEY",
+          "description": "Komodo API key",
+          "required": true,
+          "secret": true
+        },
+        {
+          "name": "KOMODO_API_SECRET",
+          "description": "Komodo API secret",
+          "required": true,
+          "secret": true
+        }
+      ]
+    },
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/samik081/mcp-komodo:0.5.0",
+      "version": "0.5.0",
+      "runtimeHint": "docker",
+      "environment_variables": [
+        {
+          "name": "KOMODO_URL",
+          "description": "URL of the Komodo instance (e.g. https://komodo.example.com)",
+          "required": true
+        },
+        {
+          "name": "KOMODO_API_KEY",
+          "description": "Komodo API key",
+          "required": true,
+          "secret": true
+        },
+        {
+          "name": "KOMODO_API_SECRET",
+          "description": "Komodo API secret",
+          "required": true,
+          "secret": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `server.json` manifest for the official MCP Registry, declaring npm and OCI package entries with required environment variables
- Add `mcp-registry` CI job to `.github/workflows/publish.yml` that runs on GitHub Release events — installs `mcp-publisher`, authenticates via GitHub OIDC, and publishes the server to the MCP Registry
- Add `mcpName` field to `package.json` with the registry-format identifier (`io.github.samik081/mcp-komodo`)
- Add `io.modelcontextprotocol.server.name` Docker label to `Dockerfile` for registry discovery

## Files changed
- `.github/workflows/publish.yml` — new `mcp-registry` job (needs `publish` + `docker`, uses OIDC `id-token: write`)
- `Dockerfile` — added MCP server name label
- `package.json` — added `mcpName` field
- `server.json` — new MCP Registry manifest (name, title, description, license, repository, npm + OCI packages with env vars)