### PR TITLE
fix: add $schema to server.json and unify descriptions for MCP Registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@samik081/mcp-komodo",
   "mcpName": "io.github.samik081/mcp-komodo",
   "version": "0.5.1",
-  "description": "MCP server for the Komodo DevOps platform — manage servers, stacks, deployments, builds, and more through AI coding tools",
+  "description": "Manage Komodo through AI assistants",
   "type": "module",
   "main": "./dist/index.js",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -1,8 +1,9 @@
 {
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.samik081/mcp-komodo",
   "version": "0.5.1",
   "title": "Komodo MCP Server",
-  "description": "MCP server for the Komodo DevOps platform — manage servers, stacks, deployments, builds, and more through AI coding tools",
+  "description": "Manage Komodo through AI assistants",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- Add required `$schema` field to `server.json` — the MCP Registry rejects submissions without it (`expected length >= 1` on `body.$schema`)
- Unify descriptions across `server.json` and `package.json` to the pattern "Manage Komodo through AI assistants" — previous description was 123 characters, exceeding the 100-character registry limit

### Files changed
- `server.json` — added `$schema` as first key, updated `description`
- `package.json` — updated `description` to match