### PR TITLE
fix: correct MCP Registry name casing to match GitHub username

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samik081/mcp-komodo",
-  "mcpName": "io.github.samik081/mcp-komodo",
+  "mcpName": "io.github.Samik081/mcp-komodo",
   "version": "0.5.2",
   "description": "Manage Komodo through AI assistants",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.samik081/mcp-komodo",
+  "name": "io.github.Samik081/mcp-komodo",
   "version": "0.5.2",
   "title": "Komodo MCP Server",
   "description": "Manage Komodo through AI assistants",


### PR DESCRIPTION
## Summary

- Fix username casing in the MCP Registry server name identifier from `samik081` to `Samik081` in both `server.json` (`name` field) and `package.json` (`mcpName` field)
- The MCP Registry `publish` CI job was failing with a 403 because the registry derives permissions from the GitHub username (`Samik081`, capital S) but the `name` field used lowercase `samik081`
- Only the MCP Registry name identifier is changed — npm scope (`@samik081/`) and OCI identifiers (`ghcr.io/samik081/`) are unaffected as they use separate casing rules

## Files changed

- `server.json` — line 3: `io.github.samik081/mcp-komodo` → `io.github.Samik081/mcp-komodo`
- `package.json` — line 3: `io.github.samik081/mcp-komodo` → `io.github.Samik081/mcp-komodo`