### PR TITLE
fix: remove registryBaseUrl from OCI packages in server.json

### DIFF
--- a/server.json
+++ b/server.json
@@ -41,7 +41,6 @@
     },
     {
       "registryType": "oci",
-      "registryBaseUrl": "https://ghcr.io",
       "identifier": "ghcr.io/samik081/mcp-komodo:0.5.4",
       "version": "0.5.4",
       "runtimeHint": "docker",


### PR DESCRIPTION
## Summary

- Remove `registryBaseUrl` field from OCI package entries in `server.json`
- The MCP Registry rejects `registryBaseUrl` on OCI packages — OCI packages must use canonical references in the `identifier` field instead (e.g. `ghcr.io/owner/image:version`)
- `registryBaseUrl` is kept on npm package entries (`https://registry.npmjs.org`)

Fixes registry publish error: `OCI packages must not have 'registryBaseUrl' field`.