### PR TITLE
fix: remove redundant version and runtimeHint from OCI package in server.json

### DIFF
--- a/server.json
+++ b/server.json
@@ -42,8 +42,6 @@
     {
       "registryType": "oci",
       "identifier": "ghcr.io/samik081/mcp-komodo:0.5.5",
-      "version": "0.5.5",
-      "runtimeHint": "docker",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
- Remove `version` and `runtimeHint` fields from the OCI package entry in `server.json`
- The `version` field is redundant for OCI packages since the version is already encoded in the `identifier` tag (e.g., `ghcr.io/samik081/mcp-komodo:0.5.5`)
- The `runtimeHint` field is not part of the MCP Registry schema for OCI packages
- This brings `server.json` into full compliance with the MCP Registry schema