### PR TITLE
fix: correct MCP server name casing in Dockerfile OCI annotation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,5 @@ USER mcp
 ENV MCP_PORT=3000
 ENV MCP_HOST=0.0.0.0
 EXPOSE 3000
-LABEL io.modelcontextprotocol.server.name="io.github.samik081/mcp-komodo"
+LABEL io.modelcontextprotocol.server.name="io.github.Samik081/mcp-komodo"
 ENTRYPOINT ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary
- Fix casing of GitHub username in the `io.modelcontextprotocol.server.name` Docker label from `io.github.samik081/mcp-komodo` to `io.github.Samik081/mcp-komodo`
- The MCP Registry validates that this OCI annotation matches the registered server name exactly (case-sensitive), and rejects publishing when the casing doesn't match
- Only `Dockerfile` is modified — a single-character change (`s` → `S`)