### PR TITLE
docs: add API Compatibility section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ MCP server for the [Komodo](https://komo.do) DevOps platform. Manage servers, st
 - **Remote MCP** via HTTP transport (`MCP_TRANSPORT=http`) using the Streamable HTTP protocol
 - **TypeScript/ESM** with full type safety
 
+## API Compatibility
+
+Built for Komodo **1.19.5**.
+
 ## Quick Start
 
 Run the server directly with npx:


### PR DESCRIPTION
## Summary

- Added a new "API Compatibility" section to README.md, placed between Features and Quick Start
- Documents the SDK-pinned Komodo version: **1.19.5**
- Uses "Built for" wording since the server uses the `komodo_client` SDK which pins to a specific API version