### PR TITLE
ci: add docker job timeout and make npm publish idempotent

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,13 +39,22 @@ jobs:
           registry-url: https://registry.npmjs.org
       - run: npm ci
       - run: npm run build
-      - run: npm publish --provenance --access public
+      - name: Publish to npm (skip if version already published)
+        run: |
+          name=$(node -p "require('./package.json').name")
+          version=$(node -p "require('./package.json').version")
+          if [ -n "$(npm view "$name@$version" version 2>/dev/null)" ]; then
+            echo "::notice::$name@$version already on npm — skipping publish"
+          else
+            npm publish --provenance --access public
+          fi
 
   docker:
     name: Build & Push Docker Image
     if: github.event_name == 'release'
     needs: ci
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary
Hardens the release workflow (`.github/workflows/publish.yml`) against partial-failure release runs. Previously a hung Docker build could run until GitHub's 6-hour max timeout, leaving the image unpublished and — because the MCP Registry job depends on both the `docker` and `publish` jobs — skipping the MCP Registry publish. A re-fired release would then also fail on the npm publish step because the version was already published.

## Changes
- **`docker` job: add `timeout-minutes: 30`** — a hung multi-arch build (the `linux/arm64` leg builds under QEMU emulation) now fails fast in 30 minutes instead of consuming the full 6-hour budget and blocking downstream jobs.
- **`publish` job: make npm publish idempotent** — the step now checks whether the package version is already on the npm registry and skips publishing if so (`npm view "$name@$version"`) instead of hard-failing on a duplicate. This lets a release be safely re-fired to recover a partially-failed run: the `publish` job succeeds as a no-op, so the dependent `mcp-registry` job is no longer cascade-skipped.

## Notes
- Purely CI/CD — no runtime code or package contents change. No version bump or release.